### PR TITLE
ci: add deadcode check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,13 @@ jobs:
         run: GOWORK=off go vet ./...
 
       - name: Deadcode
-        run: GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
+        run: |
+          output_file=$(mktemp)
+          GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... > "$output_file"
+          if [ -s "$output_file" ]; then
+            cat "$output_file"
+            exit 1
+          fi
 
       - name: Test
         run: GOWORK=off go test -count=1 ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify module cache
+        run: GOWORK=off go mod verify
+
+      - name: Check go.mod tidy
+        run: |
+          GOWORK=off go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Vet
+        run: GOWORK=off go vet ./...
+
+      - name: Deadcode
+        run: GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
+
+      - name: Test
+        run: GOWORK=off go test -count=1 ./...
+
+      - name: Build
+        run: GOWORK=off go build -trimpath -o bin/photoscrawl ./cmd/photoscrawl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,6 @@ jobs:
         run: GOWORK=off go test -count=1 ./...
 
       - name: Build
-        run: GOWORK=off go build -trimpath -o bin/photoscrawl ./cmd/photoscrawl
+        run: |
+          mkdir -p bin
+          GOWORK=off go build -trimpath -o bin/photoscrawl ./cmd/photoscrawl

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/joshp123/photoscrawl
 
 go 1.26.2
 
-require github.com/openclaw/crawlkit v0.11.0
+require (
+	github.com/openclaw/crawlkit v0.11.0
+	modernc.org/sqlite v1.50.1
+)
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -15,5 +18,4 @@ require (
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	modernc.org/sqlite v1.50.1 // indirect
 )

--- a/internal/photos/local_media.go
+++ b/internal/photos/local_media.go
@@ -88,14 +88,6 @@ func AttachLocalMediaPaths(snapshot *LibrarySnapshot, libraryPath string) error 
 	return nil
 }
 
-func FindLocalMediaCandidates(libraryPath, localIdentifier string) ([]LocalMediaCandidate, error) {
-	index, err := localMediaIndex(libraryPath)
-	if err != nil {
-		return nil, err
-	}
-	return index.Candidates(localIdentifier), nil
-}
-
 func localMediaIndex(libraryPath string) (LocalMediaIndex, error) {
 	roots := []struct {
 		path  string

--- a/internal/place/run.go
+++ b/internal/place/run.go
@@ -63,18 +63,6 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 	return result, nil
 }
 
-func RunRaw(ctx context.Context, opts Options) (Result, error) {
-	input, err := loadInput(opts.InputPath)
-	if err != nil {
-		return Result{}, err
-	}
-	radius := opts.RadiusMeters
-	if radius <= 0 {
-		radius = defaultRadiusMeters
-	}
-	return rawAppleResult(ctx, input, radius)
-}
-
 func LoadResult(path string) (Result, error) {
 	reader, closeReader, err := inputReader(path)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add an enforced Go deadcode CI gate pinned to `golang.org/x/tools/cmd/deadcode@v0.45.0`
- remove unreachable helpers reported by deadcode
- fix workflow hygiene caught by CI: tidy go.mod and create the build output directory

## Validation
- `git diff --check`
- `GOWORK=off go mod tidy`
- `GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go build ./cmd/photoscrawl`
- `autoreview --mode branch --base origin/main --thinking low` clean
