### PR TITLE
fix: add asset tombstone policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add explicit asset and resource tombstones, lossless schema migration, and merge-only crawl updates that never infer deletion from a missing snapshot row.
 - Add loopback-only OpenAI-compatible local vision classification for LM Studio, with thanks to @mbelinky.
 - Align the module path with `openclaw/photoscrawl`, add CrawlKit control metadata for launcher discovery, use current dependencies, and prefer MapKit reverse geocoding on macOS 26.
 - Update CrawlKit to v0.14.2, modernc SQLite to v1.54.0, and Go to 1.26.5.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ go run ./cmd/photoscrawl metadata --json
 go run ./cmd/photoscrawl init --json
 go run ./cmd/photoscrawl status --json
 go run ./cmd/photoscrawl crawl --library "$HOME/Pictures/Photos Library.photoslibrary" --json
+go run ./cmd/photoscrawl crawl --provider sqlite --library "/path/to/scratch.photoslibrary" --json
 go run ./cmd/photoscrawl classify --limit 100 --json
 go run ./cmd/photoscrawl classify --local-model gemma4:e4b --limit 20 --json
 go run ./cmd/photoscrawl classify --local-model photoscrawl-qwen3-vl-8b --local-model-api openai --local-model-url http://127.0.0.1:1234/v1 --limit 20 --json
@@ -59,6 +60,12 @@ source. If PhotoKit is unavailable or denied, the POC falls back to a read-only
 local package media paths for derivatives/renders/originals when they exist, so
 content classification can use local files without changing Photos or iCloud
 state. Every imported asset is queued for `classify`.
+
+Crawls merge into the archive. An asset missing from a later enumeration stays
+live; only an explicit provider deletion signal creates a tombstone. Asset
+tombstones retain their reason and also tombstone archived resource rows such as
+derivatives and thumbnails. A later explicit live record restores the asset and
+the resources present in that record without discarding other archive history.
 
 `classify` drains that queue into evidence-backed local metadata observations.
 With `--local-model <model>`, it also sends already-local image bytes to a local

--- a/cmd/photoscrawl/main.go
+++ b/cmd/photoscrawl/main.go
@@ -98,6 +98,7 @@ func run(ctx context.Context, args []string) error {
 		fs.SetOutput(os.Stderr)
 		dbPath := fs.String("db", "", "photos.sqlite path")
 		libraryPath := fs.String("library", "", "Photos Library.photoslibrary path")
+		providerName := fs.String("provider", "auto", "photos provider: auto or sqlite")
 		jsonFlag := fs.Bool("json", false, "write JSON")
 		formatFlag := fs.String("format", "", "output format")
 		if err := fs.Parse(args[1:]); err != nil {
@@ -110,9 +111,13 @@ func run(ctx context.Context, args []string) error {
 		if err != nil {
 			return err
 		}
+		provider, err := photos.ProviderByName(*providerName)
+		if err != nil {
+			return output.UsageError{Err: err}
+		}
 		result, err := archive.Crawl(ctx, paths, archive.CrawlOptions{
 			LibraryPath: *libraryPath,
-			Provider:    photos.NewProvider(),
+			Provider:    provider,
 		})
 		if err != nil {
 			return err

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -20,11 +20,7 @@ func Init(ctx context.Context, paths Paths) (InitResult, error) {
 	if err := os.MkdirAll(filepath.Dir(paths.Database), 0o700); err != nil {
 		return InitResult{}, err
 	}
-	db, err := store.Open(ctx, store.Options{
-		Path:          paths.Database,
-		Schema:        Schema,
-		SchemaVersion: SchemaVersion,
-	})
+	db, err := openArchiveStore(ctx, paths.Database)
 	if err != nil {
 		return InitResult{}, err
 	}
@@ -57,11 +53,7 @@ func Status(ctx context.Context, paths Paths) (control.Status, error) {
 }
 
 func counts(ctx context.Context, dbPath string) ([]control.Count, string, string, []string, error) {
-	db, err := store.Open(ctx, store.Options{
-		Path:          dbPath,
-		Schema:        Schema,
-		SchemaVersion: SchemaVersion,
-	})
+	db, err := openArchiveReadOnly(ctx, dbPath)
 	if err != nil {
 		return nil, "", "", nil, err
 	}
@@ -108,7 +100,7 @@ func usefulCounts(ctx context.Context, db *sql.DB) ([]control.Count, error) {
 		label  string
 		query  string
 	}{
-		{"asset.media_type", "assets media type", `select media_type, count(*) from asset group by media_type order by count(*) desc, media_type`},
+		{"asset.media_type", "assets media type", `select media_type, count(*) from asset where deleted_at is null group by media_type order by count(*) desc, media_type`},
 		{"resource.availability", "resources availability", `
 select case
   when available_locally <> 0 then 'local'
@@ -116,6 +108,7 @@ select case
   else 'unknown'
 end as availability, count(*)
 from asset_resource
+where deleted_at is null and asset_id in (select id from asset where deleted_at is null)
 group by availability
 order by count(*) desc, availability
 `},
@@ -123,18 +116,21 @@ order by count(*) desc, availability
 		{"observation.type", "observation type", `
 select observation_type, count(*)
 from visual_observation
+join asset on asset.id = visual_observation.asset_id and asset.deleted_at is null
 group by observation_type
 order by count(*) desc, observation_type
 `},
 		{"model_observation.type", "model observation type", `
 select observation_type, count(*)
 from model_observation
+join asset on asset.id = model_observation.asset_id and asset.deleted_at is null
 group by observation_type
 order by count(*) desc, observation_type
 `},
 		{"observation_term.type", "observation term type", `
 select term_type, count(*)
 from observation_term
+join asset on asset.id = observation_term.asset_id and asset.deleted_at is null
 group by term_type
 order by count(*) desc, term_type
 `},
@@ -151,20 +147,23 @@ order by count(*) desc, term_type
 		label string
 		query string
 	}{
-		{"asset.with_location", "assets with location", `select count(distinct asset_id) from location_observation`},
-		{"asset.without_location", "assets without location", `select count(*) from asset where id not in (select asset_id from location_observation)`},
+		{"asset.deleted", "deleted assets", `select count(*) from asset where deleted_at is not null`},
+		{"asset.active", "active assets", `select count(*) from asset where deleted_at is null`},
+		{"resource.deleted", "deleted resources", `select count(*) from asset_resource where deleted_at is not null`},
+		{"asset.with_location", "assets with location", `select count(distinct location_observation.asset_id) from location_observation join asset on asset.id = location_observation.asset_id where asset.deleted_at is null`},
+		{"asset.without_location", "assets without location", `select count(*) from asset where deleted_at is null and id not in (select asset_id from location_observation)`},
 		{"asset.with_observation", "assets with local observations", `select count(distinct asset_id) from (
   select asset_id from visual_observation
   union
   select asset_id from model_observation
-)`},
-		{"asset.without_observation", "assets without local observations", `select count(*) from asset where id not in (
+) where asset_id in (select id from asset where deleted_at is null)`},
+		{"asset.without_observation", "assets without local observations", `select count(*) from asset where deleted_at is null and id not in (
   select asset_id from visual_observation
   union
   select asset_id from model_observation
 )`},
-		{"asset.with_local_resource", "assets with local resource", `select count(distinct asset_id) from asset_resource where available_locally <> 0`},
-		{"asset.needing_download", "assets needing download", `select count(distinct asset_id) from asset_resource where needs_download <> 0`},
+		{"asset.with_local_resource", "assets with local resource", `select count(distinct asset_resource.asset_id) from asset_resource join asset on asset.id = asset_resource.asset_id where asset_resource.deleted_at is null and asset.deleted_at is null and available_locally <> 0`},
+		{"asset.needing_download", "assets needing download", `select count(distinct asset_resource.asset_id) from asset_resource join asset on asset.id = asset_resource.asset_id where asset_resource.deleted_at is null and asset.deleted_at is null and needs_download <> 0`},
 	}
 	for _, scalar := range scalarQueries {
 		var value int64
@@ -200,24 +199,24 @@ func groupedCounts(ctx context.Context, db *sql.DB, prefix, labelPrefix, query s
 
 func statusSummary(ctx context.Context, db *sql.DB) (string, error) {
 	var assets, located, observations, pending int64
-	if err := db.QueryRowContext(ctx, `select count(*) from asset`).Scan(&assets); err != nil {
+	if err := db.QueryRowContext(ctx, `select count(*) from asset where deleted_at is null`).Scan(&assets); err != nil {
 		return "", err
 	}
-	if err := db.QueryRowContext(ctx, `select count(distinct asset_id) from location_observation`).Scan(&located); err != nil {
+	if err := db.QueryRowContext(ctx, `select count(distinct location_observation.asset_id) from location_observation join asset on asset.id = location_observation.asset_id where asset.deleted_at is null`).Scan(&located); err != nil {
 		return "", err
 	}
 	if err := db.QueryRowContext(ctx, `select count(distinct asset_id) from (
   select asset_id from visual_observation
   union
   select asset_id from model_observation
-)`).Scan(&observations); err != nil {
+) where asset_id in (select id from asset where deleted_at is null)`).Scan(&observations); err != nil {
 		return "", err
 	}
 	if err := db.QueryRowContext(ctx, `select count(*) from classification_queue where state = 'pending'`).Scan(&pending); err != nil {
 		return "", err
 	}
 	if assets == 0 {
-		return "photos.sqlite is initialized but has no crawled assets", nil
+		return "photos.sqlite is initialized but has no active crawled assets", nil
 	}
 	return fmt.Sprintf("%d assets; %d with raw GPS; %d with local observations; %d pending classification", assets, located, observations, pending), nil
 }

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -2,8 +2,11 @@ package archive
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/openclaw/crawlkit/store"
 )
 
 func TestInitAndStatus(t *testing.T) {
@@ -37,5 +40,191 @@ func TestInitAndStatus(t *testing.T) {
 	}
 	if len(after.Counts) == 0 {
 		t.Fatal("status returned no counts")
+	}
+}
+
+func TestSearchDoesNotCreateOrRewriteDatabase(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	missingPath := filepath.Join(t.TempDir(), "missing.sqlite")
+	if _, err := Search(ctx, Paths{Database: missingPath}, SearchOptions{Query: "fixture"}); err == nil {
+		t.Fatal("search on missing database should fail")
+	}
+	if _, err := os.Stat(missingPath); !os.IsNotExist(err) {
+		t.Fatalf("search created missing database: %v", err)
+	}
+	unrelatedPath := filepath.Join(t.TempDir(), "unrelated.sqlite")
+	unrelated, err := store.Open(ctx, store.Options{Path: unrelatedPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := unrelated.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Search(ctx, Paths{Database: unrelatedPath}, SearchOptions{Query: "fixture"}); err == nil {
+		t.Fatal("search on unrelated database should fail")
+	}
+	unrelated, err = store.OpenReadOnly(ctx, unrelatedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var unrelatedTables int
+	if err := unrelated.DB().QueryRowContext(ctx, `select count(*) from sqlite_master where type = 'table'`).Scan(&unrelatedTables); err != nil {
+		unrelated.Close()
+		t.Fatal(err)
+	}
+	if err := unrelated.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if unrelatedTables != 0 {
+		t.Fatalf("search mutated unrelated database with %d tables", unrelatedTables)
+	}
+	versionedPath := filepath.Join(t.TempDir(), "versioned-unrelated.sqlite")
+	versioned, err := store.Open(ctx, store.Options{
+		Path:          versionedPath,
+		Schema:        `create table sentinel(value text);`,
+		SchemaVersion: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := versioned.DB().ExecContext(ctx, `insert into sentinel values ('preserved')`); err != nil {
+		versioned.Close()
+		t.Fatal(err)
+	}
+	if err := versioned.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Search(ctx, Paths{Database: versionedPath}, SearchOptions{Query: "fixture"}); err == nil {
+		t.Fatal("search on unrelated versioned database should fail")
+	}
+	if _, err := Init(ctx, Paths{Database: versionedPath}); err == nil {
+		t.Fatal("init on unrelated versioned database should fail")
+	}
+	versioned, err = store.OpenReadOnly(ctx, versionedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	version, err := versioned.SchemaVersion(ctx)
+	if err != nil {
+		versioned.Close()
+		t.Fatal(err)
+	}
+	var sentinel string
+	if err := versioned.DB().QueryRowContext(ctx, `select value from sentinel`).Scan(&sentinel); err != nil {
+		versioned.Close()
+		t.Fatal(err)
+	}
+	var photoscrawlTables int
+	if err := versioned.DB().QueryRowContext(ctx, `select count(*) from sqlite_master where type = 'table' and name = 'asset'`).Scan(&photoscrawlTables); err != nil {
+		versioned.Close()
+		t.Fatal(err)
+	}
+	if err := versioned.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if version != 1 || sentinel != "preserved" || photoscrawlTables != 0 {
+		t.Fatalf("search mutated versioned database: version=%d sentinel=%q photoscrawl_tables=%d", version, sentinel, photoscrawlTables)
+	}
+
+	paths := testPaths(t)
+	if _, err := Init(ctx, paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(paths.Database, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Search(ctx, paths, SearchOptions{Query: "fixture"}); err != nil {
+		t.Fatalf("search read-only database: %v", err)
+	}
+	info, err := os.Stat(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o400 {
+		t.Fatalf("search changed database mode to %o", info.Mode().Perm())
+	}
+}
+
+func TestInitRejectsUnrelatedCurrentVersionDatabase(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "unrelated-v2.sqlite")
+	db, err := store.Open(ctx, store.Options{Path: dbPath, Schema: `create table sentinel(value text);`, SchemaVersion: SchemaVersion})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.DB().ExecContext(ctx, `insert into sentinel values ('preserved')`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Init(ctx, Paths{Database: dbPath}); err == nil {
+		t.Fatal("init on unrelated current-version database should fail")
+	}
+	if _, err := Search(ctx, Paths{Database: dbPath}, SearchOptions{Query: "fixture"}); err == nil {
+		t.Fatal("search on unrelated current-version database should fail")
+	}
+	db, err = store.OpenReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var sentinel string
+	if err := db.DB().QueryRowContext(ctx, `select value from sentinel`).Scan(&sentinel); err != nil {
+		t.Fatal(err)
+	}
+	var photoscrawlTables int
+	if err := db.DB().QueryRowContext(ctx, `select count(*) from sqlite_master where type = 'table' and name = 'asset'`).Scan(&photoscrawlTables); err != nil {
+		t.Fatal(err)
+	}
+	if sentinel != "preserved" || photoscrawlTables != 0 {
+		t.Fatalf("unrelated v2 database mutated: sentinel=%q photoscrawl_tables=%d", sentinel, photoscrawlTables)
+	}
+}
+
+func TestInitOnlyAdoptsTrulyEmptyUnversionedDatabase(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tests := []struct {
+		name          string
+		schema        string
+		schemaVersion int
+	}{
+		{name: "view-only", schema: `create view sentinel as select 'preserved' as value;`},
+		{name: "versioned-empty", schemaVersion: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "unrelated.sqlite")
+			db, err := store.Open(ctx, store.Options{Path: dbPath, Schema: test.schema, SchemaVersion: test.schemaVersion})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Init(ctx, Paths{Database: dbPath}); err == nil {
+				t.Fatal("init on unowned database should fail")
+			}
+			db, err = store.OpenReadOnly(ctx, dbPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			version, err := db.SchemaVersion(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var photoscrawlTables int
+			if err := db.DB().QueryRowContext(ctx, `select count(*) from sqlite_master where type = 'table' and name = 'asset'`).Scan(&photoscrawlTables); err != nil {
+				t.Fatal(err)
+			}
+			if version != test.schemaVersion || photoscrawlTables != 0 {
+				t.Fatalf("unowned database mutated: version=%d tables=%d", version, photoscrawlTables)
+			}
+		})
 	}
 }

--- a/internal/archive/classify.go
+++ b/internal/archive/classify.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/openclaw/crawlkit/store"
 )
 
 const (
@@ -104,11 +102,7 @@ func Classify(ctx context.Context, paths Paths, opts ClassifyOptions) (ClassifyR
 		limit = 1000
 	}
 
-	db, err := store.Open(ctx, store.Options{
-		Path:          paths.Database,
-		Schema:        Schema,
-		SchemaVersion: SchemaVersion,
-	})
+	db, err := openArchiveStore(ctx, paths.Database)
 	if err != nil {
 		return ClassifyResult{}, err
 	}
@@ -225,6 +219,7 @@ select q.id, q.asset_id, q.source_library_id, q.needs_download,
 from classification_queue q
 join asset a on a.id = q.asset_id
 where q.state in (` + classifyQueueStates(includeMetadataClassified) + `)
+  and a.deleted_at is null
 order by case q.state when 'pending' then 0 else 1 end, a.creation_date desc, q.id
 `
 	args := []any{}
@@ -287,6 +282,7 @@ func loadClassifyResources(ctx context.Context, tx *sql.Tx, assetID string) ([]c
 select id, resource_type, uti, original_filename, local_path, available_locally, needs_download
 from asset_resource
 where asset_id = ?
+  and deleted_at is null
 order by resource_type, original_filename
 `, assetID)
 	if err != nil {

--- a/internal/archive/classify_test.go
+++ b/internal/archive/classify_test.go
@@ -66,6 +66,7 @@ func TestClassifyLocalModelWritesTypedObservations(t *testing.T) {
 				Height:          80,
 				Resources: []photos.Resource{
 					{
+						SourceIdentifier: "fixture-local-photo",
 						Type:             "photo",
 						UTI:              "public.jpeg",
 						OriginalFilename: "fixture.jpeg",
@@ -249,6 +250,7 @@ func TestClassifyLocalModelTerminatesRemoteNonImageRows(t *testing.T) {
 				Height:          80,
 				Resources: []photos.Resource{
 					{
+						SourceIdentifier: "fixture-remote-video",
 						Type:             "video",
 						UTI:              "com.apple.quicktime-movie",
 						OriginalFilename: "fixture.mov",
@@ -312,6 +314,7 @@ func TestClassifyLocalModelKeepsRemoteImagesRetryable(t *testing.T) {
 				Height:          80,
 				Resources: []photos.Resource{
 					{
+						SourceIdentifier: "fixture-remote-photo",
 						Type:             "photo",
 						UTI:              "public.jpeg",
 						OriginalFilename: "fixture.jpeg",
@@ -386,6 +389,7 @@ func TestClassifyLocalModelPrioritizesPendingRowsBeforeWaitingRows(t *testing.T)
 				Height:          80,
 				Resources: []photos.Resource{
 					{
+						SourceIdentifier: "newer-remote-photo",
 						Type:             "photo",
 						UTI:              "public.jpeg",
 						OriginalFilename: "remote.jpeg",
@@ -403,6 +407,7 @@ func TestClassifyLocalModelPrioritizesPendingRowsBeforeWaitingRows(t *testing.T)
 				Height:          80,
 				Resources: []photos.Resource{
 					{
+						SourceIdentifier: "older-local-photo",
 						Type:             "photo",
 						UTI:              "public.jpeg",
 						OriginalFilename: "local.jpeg",

--- a/internal/archive/crawl.go
+++ b/internal/archive/crawl.go
@@ -14,7 +14,6 @@ import (
 
 	crawlconfig "github.com/openclaw/crawlkit/config"
 	"github.com/openclaw/crawlkit/state"
-	"github.com/openclaw/crawlkit/store"
 	"github.com/openclaw/photoscrawl/internal/photos"
 )
 
@@ -33,6 +32,8 @@ type CrawlResult struct {
 	AssetsNew             int    `json:"assets_new"`
 	AssetsChanged         int    `json:"assets_changed"`
 	AssetsUnchanged       int    `json:"assets_unchanged"`
+	AssetsDeleted         int    `json:"assets_deleted"`
+	AssetsRestored        int    `json:"assets_restored"`
 	ResourcesSeen         int    `json:"resources_seen"`
 	AlbumMembershipsSeen  int    `json:"album_memberships_seen"`
 	LocationsSeen         int    `json:"locations_seen"`
@@ -72,12 +73,11 @@ func Crawl(ctx context.Context, paths Paths, opts CrawlOptions) (CrawlResult, er
 	if err := photos.AttachLocalMediaPaths(&snapshot, absLibraryPath); err != nil {
 		return CrawlResult{}, fmt.Errorf("resolve local Photos media paths: %w", err)
 	}
+	if err := validateSnapshotResourceSourceIdentifiers(snapshot); err != nil {
+		return CrawlResult{}, err
+	}
 
-	db, err := store.Open(ctx, store.Options{
-		Path:          paths.Database,
-		Schema:        Schema,
-		SchemaVersion: SchemaVersion,
-	})
+	db, err := openArchiveStore(ctx, paths.Database)
 	if err != nil {
 		return CrawlResult{}, err
 	}
@@ -161,12 +161,16 @@ values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		if strings.TrimSpace(asset.LocalIdentifier) == "" {
 			continue
 		}
+		asset, deleted, err := c.normalizeAssetDeletion(asset)
+		if err != nil {
+			return err
+		}
 		assetID := stableID("asset", sourceID, asset.LocalIdentifier)
 		fingerprint, err := assetFingerprint(asset)
 		if err != nil {
 			return err
 		}
-		previousFingerprint, seenBefore, err := c.previousAssetFingerprint(ctx, sourceID, assetID)
+		previousFingerprint, previouslyDeleted, seenBefore, err := c.previousAssetState(ctx, sourceID, assetID)
 		if err != nil {
 			return err
 		}
@@ -178,7 +182,13 @@ values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		default:
 			c.result.AssetsUnchanged++
 		}
-		if err := c.upsertAsset(ctx, tx, sourceID, snapshotID, assetID, fingerprint, seenBefore, asset); err != nil {
+		if deleted && !previouslyDeleted {
+			c.result.AssetsDeleted++
+		}
+		if !deleted && previouslyDeleted {
+			c.result.AssetsRestored++
+		}
+		if err := c.upsertAsset(ctx, tx, sourceID, snapshotID, assetID, fingerprint, deleted, asset); err != nil {
 			return err
 		}
 	}
@@ -210,57 +220,79 @@ where source_library_id = ? and last_seen_snapshot_id <> ?
 	return nil
 }
 
-func (c *crawlImporter) upsertAsset(ctx context.Context, tx *sql.Tx, sourceID, snapshotID, assetID, fingerprint string, seenBefore bool, asset photos.Asset) error {
+func (c *crawlImporter) upsertAsset(ctx context.Context, tx *sql.Tx, sourceID, snapshotID, assetID, fingerprint string, deleted bool, asset photos.Asset) error {
 	metadataJSON, err := jsonText(asset.Metadata)
 	if err != nil {
 		return err
 	}
-	if _, err := c.stmts.asset.ExecContext(ctx, assetID, asset.LocalIdentifier, asset.MediaType, asset.MediaSubtypes, asset.CreationDate, asset.ModificationDate, asset.AddedDate, asset.TimezoneName, asset.Width, asset.Height, asset.DurationSeconds, boolInt(asset.Favorite), boolInt(asset.Hidden), asset.BurstIdentifier, boolInt(asset.RepresentsBurst), sourceID, metadataJSON); err != nil {
+	assetArgs := []any{assetID, asset.LocalIdentifier, asset.MediaType, asset.MediaSubtypes, asset.CreationDate, asset.ModificationDate, asset.AddedDate, asset.TimezoneName, asset.Width, asset.Height, asset.DurationSeconds, boolInt(asset.Favorite), boolInt(asset.Hidden), asset.BurstIdentifier, boolInt(asset.RepresentsBurst), sourceID, metadataJSON}
+	assetStatement := c.stmts.assetLive
+	if deleted {
+		assetStatement = c.stmts.assetTombstone
+		assetArgs = append(assetArgs, asset.DeletedAt, asset.DeletionSource, asset.DeletionReason)
+	}
+	if _, err := assetStatement.ExecContext(ctx, assetArgs...); err != nil {
 		return fmt.Errorf("upsert asset %s: %w", assetID, err)
 	}
-
-	if seenBefore {
-		if err := resetAssetDerivedRows(ctx, tx, assetID); err != nil {
-			return err
+	evidenceKind := "asset_metadata"
+	evidencePointer := "asset:" + asset.LocalIdentifier
+	deletionTimestampSource := ""
+	if deleted {
+		evidenceKind = "asset_tombstone"
+		evidencePointer += "/tombstone:" + asset.DeletedAt
+		if value, ok := asset.Metadata["deletion_timestamp_source"].(string); ok {
+			deletionTimestampSource = strings.TrimSpace(value)
 		}
 	}
-	if err := c.insertEvidence(ctx, tx, assetID, "asset_metadata", c.snapshot.Provider, "asset:"+asset.LocalIdentifier, map[string]any{
-		"media_type":        asset.MediaType,
-		"media_subtypes":    asset.MediaSubtypes,
-		"creation_date":     asset.CreationDate,
-		"modification_date": asset.ModificationDate,
-		"favorite":          asset.Favorite,
-		"hidden":            asset.Hidden,
-		"width":             asset.Width,
-		"height":            asset.Height,
+	if err := c.insertEvidence(ctx, tx, assetID, evidenceKind, c.snapshot.Provider, evidencePointer, map[string]any{
+		"media_type":                asset.MediaType,
+		"media_subtypes":            asset.MediaSubtypes,
+		"creation_date":             asset.CreationDate,
+		"modification_date":         asset.ModificationDate,
+		"favorite":                  asset.Favorite,
+		"hidden":                    asset.Hidden,
+		"width":                     asset.Width,
+		"height":                    asset.Height,
+		"deleted_at":                asset.DeletedAt,
+		"deletion_source":           asset.DeletionSource,
+		"deletion_reason":           asset.DeletionReason,
+		"deletion_timestamp_source": deletionTimestampSource,
 	}); err != nil {
 		return err
 	}
-	for i, resource := range asset.Resources {
-		if err := c.insertResource(ctx, tx, assetID, asset.LocalIdentifier, i, resource); err != nil {
+	for resourceIndex, resource := range asset.Resources {
+		if err := c.insertResource(ctx, tx, assetID, asset.LocalIdentifier, resourceIndex, resource, deleted, asset); err != nil {
 			return err
 		}
 	}
-	for _, album := range asset.Albums {
-		if err := c.insertAlbum(ctx, tx, assetID, album); err != nil {
-			return err
+	if !deleted {
+		for _, album := range asset.Albums {
+			if err := c.insertAlbum(ctx, tx, assetID, album); err != nil {
+				return err
+			}
+		}
+		if asset.Location != nil {
+			if err := c.insertLocation(ctx, tx, assetID, asset.LocalIdentifier, *asset.Location); err != nil {
+				return err
+			}
 		}
 	}
-	if asset.Location != nil {
-		if err := c.insertLocation(ctx, tx, assetID, asset.LocalIdentifier, *asset.Location); err != nil {
+	if deleted {
+		if err := c.tombstoneAssetSubordinates(ctx, tx, assetID, asset); err != nil {
 			return err
 		}
-	}
-	if err := c.insertFTS(ctx, tx, assetID, asset); err != nil {
-		return err
-	}
-	if err := c.upsertClassifyQueue(ctx, tx, sourceID, assetID, asset); err != nil {
-		return err
+	} else {
+		if err := c.insertFTS(ctx, tx, assetID, asset); err != nil {
+			return err
+		}
+		if err := c.upsertClassifyQueue(ctx, tx, sourceID, assetID); err != nil {
+			return err
+		}
 	}
 	return c.upsertSeenAsset(ctx, tx, sourceID, assetID, snapshotID, fingerprint)
 }
 
-func (c *crawlImporter) insertResource(ctx context.Context, tx *sql.Tx, assetID, localIdentifier string, index int, resource photos.Resource) error {
+func (c *crawlImporter) insertResource(ctx context.Context, tx *sql.Tx, assetID, localIdentifier string, resourceIndex int, resource photos.Resource, deleted bool, asset photos.Asset) error {
 	evidenceValue := map[string]any{
 		"availability":      resource.Availability,
 		"available_locally": resource.AvailableLocally,
@@ -270,11 +302,85 @@ func (c *crawlImporter) insertResource(ctx context.Context, tx *sql.Tx, assetID,
 		"local_path":        resource.LocalPath,
 		"metadata":          resource.Metadata,
 	}
-	resourceID := stableID("asset_resource", assetID, fmt.Sprintf("%06d", index), resource.Type, resource.UTI, resource.OriginalFilename)
-	if _, err := c.stmts.resource.ExecContext(ctx, resourceID, assetID, resource.Type, resource.UTI, resource.OriginalFilename, resource.LocalPath, resource.FileSize, resource.StableHash, boolInt(resource.AvailableLocally), boolInt(resource.NeedsDownload)); err != nil {
+	sourceIdentifier := strings.TrimSpace(resource.SourceIdentifier)
+	resourceID, err := resolveResourceID(ctx, tx, assetID, sourceIdentifier, resourceIndex, resource)
+	if err != nil {
+		return err
+	}
+	args := []any{resourceID, assetID, sourceIdentifier, resource.Type, resource.UTI, resource.OriginalFilename, resource.LocalPath, resource.FileSize, resource.StableHash, boolInt(resource.AvailableLocally), boolInt(resource.NeedsDownload)}
+	statement := c.stmts.resource
+	evidenceKind := "asset_resource"
+	pointer := "asset:" + localIdentifier + "/resource:" + resourceID
+	if deleted {
+		statement = c.stmts.resourceTombstone
+		args = append(args, asset.DeletedAt, asset.DeletionSource)
+		evidenceKind = "asset_resource_tombstone"
+		pointer += "/tombstone:" + asset.DeletedAt
+	}
+	if _, err := statement.ExecContext(ctx, args...); err != nil {
 		return fmt.Errorf("insert asset resource: %w", err)
 	}
-	return c.insertEvidence(ctx, tx, assetID, "asset_resource", c.snapshot.Provider, "asset:"+localIdentifier+"/resource:"+resourceID, evidenceValue)
+	return c.insertEvidence(ctx, tx, assetID, evidenceKind, c.snapshot.Provider, pointer, evidenceValue)
+}
+
+func validateSnapshotResourceSourceIdentifiers(snapshot photos.LibrarySnapshot) error {
+	for _, asset := range snapshot.Assets {
+		seen := make(map[string]struct{}, len(asset.Resources))
+		for _, resource := range asset.Resources {
+			sourceIdentifier := strings.TrimSpace(resource.SourceIdentifier)
+			if sourceIdentifier == "" {
+				return fmt.Errorf("asset %q resource %q is missing a stable source identifier", asset.LocalIdentifier, resource.Type)
+			}
+			if _, exists := seen[sourceIdentifier]; exists {
+				return fmt.Errorf("asset %q has duplicate resource source identifier %q", asset.LocalIdentifier, sourceIdentifier)
+			}
+			seen[sourceIdentifier] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func resolveResourceID(ctx context.Context, tx *sql.Tx, assetID, sourceIdentifier string, resourceIndex int, resource photos.Resource) (string, error) {
+	var resourceID string
+	err := tx.QueryRowContext(ctx, `
+select id from asset_resource
+where asset_id = ? and source_identifier = ?
+limit 1
+`, assetID, sourceIdentifier).Scan(&resourceID)
+	if err == nil {
+		return resourceID, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return "", fmt.Errorf("resolve asset resource source identity: %w", err)
+	}
+	legacyID := stableID("asset_resource", assetID, fmt.Sprintf("%06d", resourceIndex), resource.Type, resource.UTI, resource.OriginalFilename)
+	err = tx.QueryRowContext(ctx, `
+select id from asset_resource
+where id = ? and asset_id = ? and coalesce(source_identifier, '') = ''
+`, legacyID, assetID).Scan(&resourceID)
+	if err == nil {
+		return resourceID, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return "", fmt.Errorf("resolve positional legacy asset resource identity: %w", err)
+	}
+	err = tx.QueryRowContext(ctx, `
+select id from asset_resource
+where asset_id = ?
+  and coalesce(source_identifier, '') = ''
+  and resource_type = ?
+  and uti = ?
+  and original_filename = ?
+order by id
+limit 1
+`, assetID, resource.Type, resource.UTI, resource.OriginalFilename).Scan(&resourceID)
+	if err == nil {
+		return resourceID, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return "", fmt.Errorf("resolve legacy asset resource identity: %w", err)
+	}
+	return stableID("asset_resource", assetID, sourceIdentifier), nil
 }
 
 func (c *crawlImporter) insertAlbum(ctx context.Context, tx *sql.Tx, assetID string, album photos.AlbumMembership) error {
@@ -311,15 +417,78 @@ func (c *crawlImporter) insertFTS(ctx context.Context, tx *sql.Tx, assetID strin
 		asset.BurstIdentifier,
 		fmt.Sprintf("%dx%d", asset.Width, asset.Height),
 	}
-	for _, resource := range asset.Resources {
-		bodyParts = append(bodyParts, resource.Type, resource.UTI, resource.OriginalFilename)
+	resourceRows, err := tx.QueryContext(ctx, `
+select resource_type, uti, original_filename
+from asset_resource
+where asset_id = ? and deleted_at is null
+order by resource_type, original_filename, id
+`, assetID)
+	if err != nil {
+		return fmt.Errorf("load merged asset resources for fts: %w", err)
 	}
-	for _, album := range asset.Albums {
-		bodyParts = append(bodyParts, album.AlbumTitle, album.AlbumKind)
+	for resourceRows.Next() {
+		var resourceType, uti, filename string
+		if err := resourceRows.Scan(&resourceType, &uti, &filename); err != nil {
+			resourceRows.Close()
+			return err
+		}
+		bodyParts = append(bodyParts, resourceType, uti, filename)
+	}
+	if err := resourceRows.Close(); err != nil {
+		return err
+	}
+	if err := resourceRows.Err(); err != nil {
+		return err
+	}
+	albumRows, err := tx.QueryContext(ctx, `
+select album_title, album_kind
+from album_membership
+where asset_id = ?
+order by album_title, album_kind, id
+`, assetID)
+	if err != nil {
+		return fmt.Errorf("load merged album memberships for fts: %w", err)
+	}
+	for albumRows.Next() {
+		var title, kind string
+		if err := albumRows.Scan(&title, &kind); err != nil {
+			albumRows.Close()
+			return err
+		}
+		bodyParts = append(bodyParts, title, kind)
+	}
+	if err := albumRows.Close(); err != nil {
+		return err
+	}
+	if err := albumRows.Err(); err != nil {
+		return err
 	}
 	body := strings.Join(nonEmpty(bodyParts...), " ")
+	if _, err := c.stmts.deleteFTS.ExecContext(ctx, assetID); err != nil {
+		return fmt.Errorf("clear asset fts: %w", err)
+	}
 	if _, err := c.stmts.fts.ExecContext(ctx, assetID, title, body); err != nil {
 		return fmt.Errorf("insert asset fts: %w", err)
+	}
+	return nil
+}
+
+func (c *crawlImporter) tombstoneAssetSubordinates(ctx context.Context, tx *sql.Tx, assetID string, asset photos.Asset) error {
+	if _, err := tx.ExecContext(ctx, `
+update asset_resource
+set deleted_at = coalesce(deleted_at, ?),
+    deletion_source = coalesce(nullif(deletion_source, ''), ?),
+    deletion_reason = coalesce(nullif(deletion_reason, ''), 'parent_asset_deleted')
+where asset_id = ?
+`, asset.DeletedAt, asset.DeletionSource, assetID); err != nil {
+		return fmt.Errorf("tombstone asset resources: %w", err)
+	}
+	if _, err := c.stmts.deleteFTS.ExecContext(ctx, assetID); err != nil {
+		return fmt.Errorf("clear tombstoned asset fts: %w", err)
+	}
+	queueID := stableID("classification_queue", assetID)
+	if _, err := c.stmts.queue.ExecContext(ctx, queueID, assetID, stableID("source_library", c.libraryPath), "deleted", "parent_asset_deleted", 0, c.completedAt.Format(time.RFC3339Nano)); err != nil {
+		return fmt.Errorf("retire classification queue: %w", err)
 	}
 	return nil
 }
@@ -343,16 +512,36 @@ func (c *crawlImporter) upsertSeenAsset(ctx context.Context, tx *sql.Tx, sourceI
 	return nil
 }
 
-func (c *crawlImporter) upsertClassifyQueue(ctx context.Context, tx *sql.Tx, sourceID, assetID string, asset photos.Asset) error {
+func (c *crawlImporter) upsertClassifyQueue(ctx context.Context, tx *sql.Tx, sourceID, assetID string) error {
 	hasLocalContent := false
 	needsDownload := false
-	for _, resource := range asset.Resources {
-		if resource.AvailableLocally || strings.TrimSpace(resource.LocalPath) != "" {
+	rows, err := tx.QueryContext(ctx, `
+select available_locally, local_path, needs_download
+from asset_resource
+where asset_id = ? and deleted_at is null
+`, assetID)
+	if err != nil {
+		return fmt.Errorf("load merged resources for classification queue: %w", err)
+	}
+	for rows.Next() {
+		var availableLocally, resourceNeedsDownload int
+		var localPath string
+		if err := rows.Scan(&availableLocally, &localPath, &resourceNeedsDownload); err != nil {
+			rows.Close()
+			return err
+		}
+		if availableLocally != 0 || strings.TrimSpace(localPath) != "" {
 			hasLocalContent = true
 		}
-		if resource.NeedsDownload {
+		if resourceNeedsDownload != 0 {
 			needsDownload = true
 		}
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
 	}
 	needsDownload = needsDownload && !hasLocalContent
 	queueID := stableID("classification_queue", assetID)
@@ -366,45 +555,41 @@ func (c *crawlImporter) upsertClassifyQueue(ctx context.Context, tx *sql.Tx, sou
 	return nil
 }
 
-func resetAssetDerivedRows(ctx context.Context, tx *sql.Tx, assetID string) error {
-	tables := []string{
-		"asset_resource", "album_membership", "location_observation",
-		"visual_observation", "text_observation", "face_observation",
-		"model_observation", "observation_term",
-		"asset_fts", "observation_fts", "edge", "evidence_ref",
-	}
-	for _, table := range tables {
-		column := "asset_id"
-		if table == "asset_fts" {
-			column = "id"
-		}
-		query := "delete from " + store.QuoteIdent(table) + " where " + store.QuoteIdent(column) + " = ?"
-		if table == "edge" {
-			query = "delete from edge where from_id = ? or to_id = ?"
-		}
-		var err error
-		if table == "edge" {
-			_, err = tx.ExecContext(ctx, query, assetID, assetID)
-		} else {
-			_, err = tx.ExecContext(ctx, query, assetID)
-		}
-		if err != nil {
-			return fmt.Errorf("clear %s for asset: %w", table, err)
-		}
-	}
-	return nil
-}
-
-func (c *crawlImporter) previousAssetFingerprint(ctx context.Context, sourceID, assetID string) (string, bool, error) {
+func (c *crawlImporter) previousAssetState(ctx context.Context, sourceID, assetID string) (string, bool, bool, error) {
 	var fingerprint string
-	err := c.stmts.previousFingerprint.QueryRowContext(ctx, sourceID, assetID).Scan(&fingerprint)
+	var deletedAt sql.NullString
+	err := c.stmts.previousFingerprint.QueryRowContext(ctx, sourceID, assetID).Scan(&fingerprint, &deletedAt)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", false, nil
+		return "", false, false, nil
 	}
 	if err != nil {
-		return "", false, fmt.Errorf("read previous asset state: %w", err)
+		return "", false, false, fmt.Errorf("read previous asset state: %w", err)
 	}
-	return fingerprint, true, nil
+	return fingerprint, deletedAt.Valid, true, nil
+}
+
+func (c *crawlImporter) normalizeAssetDeletion(asset photos.Asset) (photos.Asset, bool, error) {
+	deletedAt := strings.TrimSpace(asset.DeletedAt)
+	reason := strings.TrimSpace(asset.DeletionReason)
+	source := strings.TrimSpace(asset.DeletionSource)
+	if deletedAt == "" && reason == "" && source == "" {
+		return asset, false, nil
+	}
+	if reason == "" {
+		return photos.Asset{}, false, fmt.Errorf("asset %q tombstone has no deletion reason", asset.LocalIdentifier)
+	}
+	if deletedAt == "" {
+		deletedAt = c.completedAt.Format(time.RFC3339Nano)
+	} else if _, err := time.Parse(time.RFC3339Nano, deletedAt); err != nil {
+		return photos.Asset{}, false, fmt.Errorf("asset %q tombstone deleted_at: %w", asset.LocalIdentifier, err)
+	}
+	if source == "" {
+		source = c.snapshot.Provider
+	}
+	asset.DeletedAt = deletedAt
+	asset.DeletionSource = source
+	asset.DeletionReason = reason
+	return asset, true, nil
 }
 
 func snapshotCounts(snapshot photos.LibrarySnapshot) (resources, albums, locations int) {

--- a/internal/archive/crawl_statements.go
+++ b/internal/archive/crawl_statements.go
@@ -7,12 +7,15 @@ import (
 
 type crawlStatements struct {
 	previousFingerprint *sql.Stmt
-	asset               *sql.Stmt
+	assetLive           *sql.Stmt
+	assetTombstone      *sql.Stmt
 	resource            *sql.Stmt
+	resourceTombstone   *sql.Stmt
 	album               *sql.Stmt
 	evidence            *sql.Stmt
 	location            *sql.Stmt
 	fts                 *sql.Stmt
+	deleteFTS           *sql.Stmt
 	queue               *sql.Stmt
 	seen                *sql.Stmt
 }
@@ -24,10 +27,12 @@ func prepareCrawlStatements(ctx context.Context, tx *sql.Tx) (*crawlStatements, 
 		query  string
 	}{
 		{&stmts.previousFingerprint, `
-select source_fingerprint from crawl_seen_asset
-where source_library_id = ? and asset_id = ?
+select seen.source_fingerprint, asset.deleted_at
+from crawl_seen_asset seen
+join asset on asset.id = seen.asset_id
+where seen.source_library_id = ? and seen.asset_id = ?
 `},
-		{&stmts.asset, `
+		{&stmts.assetLive, `
 insert into asset(id, local_identifier, media_type, media_subtypes, creation_date, modification_date, added_date, timezone_name, width, height, duration_seconds, favorite, hidden, burst_identifier, represents_burst, source_library_id, metadata_json)
 values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 on conflict(id) do update set
@@ -46,25 +51,79 @@ on conflict(id) do update set
   burst_identifier = excluded.burst_identifier,
   represents_burst = excluded.represents_burst,
   source_library_id = excluded.source_library_id,
-  metadata_json = excluded.metadata_json
+  metadata_json = excluded.metadata_json,
+  deleted_at = null,
+  deletion_source = null,
+  deletion_reason = null
+`},
+		{&stmts.assetTombstone, `
+insert into asset(id, local_identifier, media_type, media_subtypes, creation_date, modification_date, added_date, timezone_name, width, height, duration_seconds, favorite, hidden, burst_identifier, represents_burst, source_library_id, metadata_json, deleted_at, deletion_source, deletion_reason)
+values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+on conflict(id) do update set
+  deleted_at = coalesce(asset.deleted_at, excluded.deleted_at),
+  deletion_source = coalesce(nullif(asset.deletion_source, ''), excluded.deletion_source),
+  deletion_reason = coalesce(nullif(asset.deletion_reason, ''), excluded.deletion_reason)
 `},
 		{&stmts.resource, `
-insert into asset_resource(id, asset_id, resource_type, uti, original_filename, local_path, file_size, sha256, available_locally, needs_download)
-values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+insert into asset_resource(id, asset_id, source_identifier, resource_type, uti, original_filename, local_path, file_size, sha256, available_locally, needs_download)
+values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+on conflict(id) do update set
+  asset_id = excluded.asset_id,
+  source_identifier = excluded.source_identifier,
+  resource_type = excluded.resource_type,
+  uti = excluded.uti,
+  original_filename = excluded.original_filename,
+  local_path = excluded.local_path,
+  file_size = excluded.file_size,
+  sha256 = excluded.sha256,
+  available_locally = excluded.available_locally,
+  needs_download = excluded.needs_download,
+  deleted_at = null,
+  deletion_source = null,
+  deletion_reason = null
+`},
+		{&stmts.resourceTombstone, `
+insert into asset_resource(id, asset_id, source_identifier, resource_type, uti, original_filename, local_path, file_size, sha256, available_locally, needs_download, deleted_at, deletion_source, deletion_reason)
+values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'parent_asset_deleted')
+on conflict(id) do update set
+  source_identifier = coalesce(nullif(asset_resource.source_identifier, ''), excluded.source_identifier),
+  deleted_at = coalesce(asset_resource.deleted_at, excluded.deleted_at),
+  deletion_source = coalesce(nullif(asset_resource.deletion_source, ''), excluded.deletion_source),
+  deletion_reason = coalesce(nullif(asset_resource.deletion_reason, ''), excluded.deletion_reason)
 `},
 		{&stmts.album, `
 insert into album_membership(id, asset_id, album_id, album_title, album_kind)
 values (?, ?, ?, ?, ?)
+on conflict(id) do update set
+  asset_id = excluded.asset_id,
+  album_id = excluded.album_id,
+  album_title = excluded.album_title,
+  album_kind = excluded.album_kind
 `},
 		{&stmts.evidence, `
 insert into evidence_ref(id, asset_id, evidence_kind, source, pointer, value_json)
 values (?, ?, ?, ?, ?, ?)
+on conflict(id) do update set
+  asset_id = excluded.asset_id,
+  evidence_kind = excluded.evidence_kind,
+  source = excluded.source,
+  pointer = excluded.pointer,
+  value_json = excluded.value_json
 `},
 		{&stmts.location, `
 insert into location_observation(id, asset_id, latitude, longitude, altitude, horizontal_accuracy, source, evidence_id)
 values (?, ?, ?, ?, ?, ?, ?, ?)
+on conflict(id) do update set
+  asset_id = excluded.asset_id,
+  latitude = excluded.latitude,
+  longitude = excluded.longitude,
+  altitude = excluded.altitude,
+  horizontal_accuracy = excluded.horizontal_accuracy,
+  source = excluded.source,
+  evidence_id = excluded.evidence_id
 `},
 		{&stmts.fts, `insert into asset_fts(id, title, body) values (?, ?, ?)`},
+		{&stmts.deleteFTS, `delete from asset_fts where id = ?`},
 		{&stmts.queue, `
 insert into classification_queue(id, asset_id, source_library_id, state, reason, needs_download, updated_at)
 values (?, ?, ?, ?, ?, ?, ?)
@@ -99,7 +158,7 @@ func (s *crawlStatements) close() {
 	if s == nil {
 		return
 	}
-	for _, stmt := range []*sql.Stmt{s.previousFingerprint, s.asset, s.resource, s.album, s.evidence, s.location, s.fts, s.queue, s.seen} {
+	for _, stmt := range []*sql.Stmt{s.previousFingerprint, s.assetLive, s.assetTombstone, s.resource, s.resourceTombstone, s.album, s.evidence, s.location, s.fts, s.deleteFTS, s.queue, s.seen} {
 		if stmt != nil {
 			_ = stmt.Close()
 		}

--- a/internal/archive/crawl_test.go
+++ b/internal/archive/crawl_test.go
@@ -2,8 +2,10 @@ package archive
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -147,6 +149,282 @@ func TestCrawlExpandsHomeInLibraryPath(t *testing.T) {
 	}
 }
 
+func TestCrawlResourceIdentityDoesNotDependOnEnumerationPosition(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	paths := testPaths(t)
+	libraryPath := filepath.Join(t.TempDir(), "Fixture Photos Library.photoslibrary")
+	if err := mkdirLibrary(libraryPath); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := fakeSnapshot(false, false)
+	snapshot.Assets[0].Resources = append(snapshot.Assets[0].Resources, photos.Resource{
+		SourceIdentifier: "fixture-thumbnail", Type: "thumbnail", UTI: "public.jpeg", OriginalFilename: "thumb.jpg", Availability: "local", AvailableLocally: true,
+	})
+	provider := fakeProvider{snapshot: snapshot}
+	if _, err := Crawl(ctx, paths, CrawlOptions{LibraryPath: libraryPath, Provider: provider, Now: fixedClock("2026-07-18T09:00:00Z")}); err != nil {
+		t.Fatal(err)
+	}
+	db, err := openArchiveStore(ctx, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var thumbnailID string
+	if err := db.DB().QueryRowContext(ctx, `select id from asset_resource where resource_type = 'thumbnail'`).Scan(&thumbnailID); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot.Assets[0].Resources = snapshot.Assets[0].Resources[1:]
+	snapshot.Assets[0].Resources[0].OriginalFilename = "renamed-thumb.jpg"
+	snapshot.Assets[0].Resources[0].UTI = "public.heic"
+	provider.snapshot = snapshot
+	if _, err := Crawl(ctx, paths, CrawlOptions{LibraryPath: libraryPath, Provider: provider, Now: fixedClock("2026-07-18T09:30:00Z")}); err != nil {
+		t.Fatal(err)
+	}
+	db, err = openArchiveStore(ctx, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var resources, sourceIdentifiers int
+	var mergedThumbnailID, mergedFilename string
+	if err := db.DB().QueryRowContext(ctx, `select count(*), count(distinct source_identifier) from asset_resource`).Scan(&resources, &sourceIdentifiers); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DB().QueryRowContext(ctx, `select id, original_filename from asset_resource where resource_type = 'thumbnail'`).Scan(&mergedThumbnailID, &mergedFilename); err != nil {
+		t.Fatal(err)
+	}
+	if resources != 2 || sourceIdentifiers != 2 || mergedThumbnailID != thumbnailID || mergedFilename != "renamed-thumb.jpg" {
+		t.Fatalf("resource merge = rows %d identities %d thumbnail %q/%q filename %q", resources, sourceIdentifiers, mergedThumbnailID, thumbnailID, mergedFilename)
+	}
+}
+
+func TestCrawlRejectsMissingOrDuplicateResourceSourceIdentifiers(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	libraryPath := filepath.Join(t.TempDir(), "Fixture Photos Library.photoslibrary")
+	if err := mkdirLibrary(libraryPath); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name      string
+		resources []photos.Resource
+		want      string
+	}{
+		{name: "missing", resources: []photos.Resource{{Type: "photo"}}, want: "missing a stable source identifier"},
+		{name: "duplicate", resources: []photos.Resource{{SourceIdentifier: "same", Type: "photo"}, {SourceIdentifier: "same", Type: "thumbnail"}}, want: "duplicate resource source identifier"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := fakeSnapshot(false, false)
+			snapshot.Assets[0].Resources = test.resources
+			paths := testPaths(t)
+			_, err := Crawl(ctx, paths, CrawlOptions{LibraryPath: libraryPath, Provider: fakeProvider{snapshot: snapshot}, Now: fixedClock("2026-07-18T09:00:00Z")})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("crawl error = %v, want %q", err, test.want)
+			}
+			if _, statErr := os.Stat(paths.Database); !os.IsNotExist(statErr) {
+				t.Fatalf("invalid snapshot created database: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestCrawlAppliesOnlyExplicitAssetTombstonesAndRestoresLiveRows(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	paths := testPaths(t)
+	libraryPath := filepath.Join(t.TempDir(), "Fixture Photos Library.photoslibrary")
+	if err := mkdirLibrary(libraryPath); err != nil {
+		t.Fatal(err)
+	}
+	provider := fakeProvider{snapshot: fakeSnapshot(false, true)}
+	if _, err := Crawl(ctx, paths, CrawlOptions{LibraryPath: libraryPath, Provider: provider, Now: fixedClock("2026-07-18T10:00:00Z")}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Classify(ctx, paths, ClassifyOptions{All: true, Now: fixedClock("2026-07-18T10:05:00Z")}); err != nil {
+		t.Fatal(err)
+	}
+	partial := fakeSnapshot(true, false)
+	partial.Assets[0].Resources = nil
+	partial.Assets[0].Albums = nil
+	provider.snapshot = partial
+	if _, err := Crawl(ctx, paths, CrawlOptions{LibraryPath: libraryPath, Provider: provider, Now: fixedClock("2026-07-18T10:10:00Z")}); err != nil {
+		t.Fatal(err)
+	}
+	mergedSearch, err := Search(ctx, paths, SearchOptions{Query: "beach", Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mergedSearch.Results) != 1 {
+		t.Fatalf("partial merge dropped retained album from search: %#v", mergedSearch.Results)
+	}
+	db, err := openArchiveStore(ctx, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var deletedID, missingID string
+	if err := db.DB().QueryRowContext(ctx, `select id from asset where local_identifier = 'fixture-asset-1'`).Scan(&deletedID); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	var retainedNeedsDownload int
+	if err := db.DB().QueryRowContext(ctx, `select needs_download from classification_queue where asset_id = ?`, deletedID).Scan(&retainedNeedsDownload); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if retainedNeedsDownload != 1 {
+		db.Close()
+		t.Fatalf("partial merge dropped retained resource queue state: needs_download=%d", retainedNeedsDownload)
+	}
+	if err := db.DB().QueryRowContext(ctx, `select id from asset where local_identifier = 'fixture-asset-2'`).Scan(&missingID); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.DB().ExecContext(ctx, `
+insert into asset_resource(id, asset_id, source_identifier, resource_type, uti, original_filename, local_path, file_size, sha256, available_locally, needs_download)
+values ('fixture-thumbnail', ?, 'fixture-thumbnail-source', 'thumbnail', 'public.jpeg', 'thumb.jpg', '/tmp/thumb.jpg', 12, 'thumb-hash', 1, 0)
+`, deletedID); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	tombstone := fakeSnapshot(false, false)
+	tombstone.Assets[0].DeletedAt = ""
+	tombstone.Assets[0].DeletionSource = "fixture-explicit-feed"
+	tombstone.Assets[0].DeletionReason = "trashed_in_photos_library"
+	tombstone.Assets[0].Metadata = map[string]any{"deletion_timestamp_source": "crawl_observed_at"}
+	provider.snapshot = tombstone
+	result, err := Crawl(ctx, paths, CrawlOptions{LibraryPath: libraryPath, Provider: provider, Now: fixedClock("2026-07-18T11:00:00Z")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AssetsDeleted != 1 || result.AssetsRestored != 0 || result.PreviouslySeenMissing != 1 {
+		t.Fatalf("tombstone crawl = deleted %d restored %d missing %d", result.AssetsDeleted, result.AssetsRestored, result.PreviouslySeenMissing)
+	}
+	db, err = openArchiveStore(ctx, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var deletedAt, source, reason string
+	if err := db.DB().QueryRowContext(ctx, `select deleted_at, deletion_source, deletion_reason from asset where id = ?`, deletedID).Scan(&deletedAt, &source, &reason); err != nil {
+		t.Fatal(err)
+	}
+	if deletedAt != "2026-07-18T11:00:00Z" || source != "fixture-explicit-feed" || reason != "trashed_in_photos_library" {
+		t.Fatalf("asset tombstone = %q %q %q", deletedAt, source, reason)
+	}
+	var timestampSource string
+	if err := db.DB().QueryRowContext(ctx, `select json_extract(value_json, '$.deletion_timestamp_source') from evidence_ref where asset_id = ? and evidence_kind = 'asset_tombstone'`, deletedID).Scan(&timestampSource); err != nil {
+		t.Fatal(err)
+	}
+	if timestampSource != "crawl_observed_at" {
+		t.Fatalf("tombstone timestamp source = %q", timestampSource)
+	}
+	var tombstonedResources int
+	if err := db.DB().QueryRowContext(ctx, `select count(*) from asset_resource where asset_id = ? and deleted_at is not null and deletion_reason = 'parent_asset_deleted'`, deletedID).Scan(&tombstonedResources); err != nil {
+		t.Fatal(err)
+	}
+	if tombstonedResources != 2 {
+		t.Fatalf("tombstoned resources = %d, want 2", tombstonedResources)
+	}
+	var missingDeleted sql.NullString
+	var missingResources int
+	if err := db.DB().QueryRowContext(ctx, `select deleted_at from asset where id = ?`, missingID).Scan(&missingDeleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DB().QueryRowContext(ctx, `select count(*) from asset_resource where asset_id = ? and deleted_at is null`, missingID).Scan(&missingResources); err != nil {
+		t.Fatal(err)
+	}
+	if missingDeleted.Valid || missingResources != 1 {
+		t.Fatalf("not-seen asset changed: deleted=%v live resources=%d", missingDeleted, missingResources)
+	}
+	var observations int
+	if err := db.DB().QueryRowContext(ctx, `select count(*) from visual_observation where asset_id = ?`, deletedID).Scan(&observations); err != nil {
+		t.Fatal(err)
+	}
+	if observations == 0 {
+		t.Fatal("tombstone erased archived observations")
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	tombstone.Assets[0].DeletedAt = "2026-07-18T11:30:00Z"
+	tombstone.Assets[0].DeletionReason = "later_duplicate_delete"
+	provider.snapshot = tombstone
+	result, err = Crawl(ctx, paths, CrawlOptions{LibraryPath: libraryPath, Provider: provider, Now: fixedClock("2026-07-18T11:45:00Z")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AssetsDeleted != 0 {
+		t.Fatalf("repeat tombstone counted as a new deletion: %+v", result)
+	}
+	db, err = openArchiveStore(ctx, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DB().QueryRowContext(ctx, `select deleted_at, deletion_reason from asset where id = ?`, deletedID).Scan(&deletedAt, &reason); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	var thumbnailDeletedAt string
+	if err := db.DB().QueryRowContext(ctx, `select deleted_at from asset_resource where id = 'fixture-thumbnail'`).Scan(&thumbnailDeletedAt); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if deletedAt != "2026-07-18T11:00:00Z" || reason != "trashed_in_photos_library" || thumbnailDeletedAt != "2026-07-18T11:00:00Z" {
+		db.Close()
+		t.Fatalf("repeat tombstone replaced first evidence: asset=%q reason=%q thumbnail=%q", deletedAt, reason, thumbnailDeletedAt)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	search, err := Search(ctx, paths, SearchOptions{Query: "beach", Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(search.Results) != 0 {
+		t.Fatalf("tombstoned asset remained searchable: %#v", search.Results)
+	}
+
+	provider.snapshot = fakeSnapshot(true, false)
+	result, err = Crawl(ctx, paths, CrawlOptions{LibraryPath: libraryPath, Provider: provider, Now: fixedClock("2026-07-18T12:00:00Z")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AssetsRestored != 1 || result.AssetsDeleted != 0 {
+		t.Fatalf("restore crawl = restored %d deleted %d", result.AssetsRestored, result.AssetsDeleted)
+	}
+	db, err = openArchiveStore(ctx, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var restoredDeleted sql.NullString
+	if err := db.DB().QueryRowContext(ctx, `select deleted_at from asset where id = ?`, deletedID).Scan(&restoredDeleted); err != nil {
+		t.Fatal(err)
+	}
+	var liveResources, retainedTombstones int
+	if err := db.DB().QueryRowContext(ctx, `select count(*) from asset_resource where asset_id = ? and deleted_at is null`, deletedID).Scan(&liveResources); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DB().QueryRowContext(ctx, `select count(*) from asset_resource where asset_id = ? and deleted_at is not null`, deletedID).Scan(&retainedTombstones); err != nil {
+		t.Fatal(err)
+	}
+	if restoredDeleted.Valid || liveResources != 1 || retainedTombstones != 1 {
+		t.Fatalf("restored asset = deleted %v live resources %d retained tombstones %d", restoredDeleted, liveResources, retainedTombstones)
+	}
+}
+
 func testPaths(t *testing.T) Paths {
 	t.Helper()
 	root := t.TempDir()
@@ -212,7 +490,7 @@ func fakeSnapshot(changed, includeSecond bool) photos.LibrarySnapshot {
 					HorizontalAccuracy: &accuracy,
 				},
 				Resources: []photos.Resource{
-					{Type: "photo", UTI: "public.heic", OriginalFilename: "Screenshot Beach Fixture.heic", Availability: "remote", NeedsDownload: true},
+					{SourceIdentifier: "fixture-photo", Type: "photo", UTI: "public.heic", OriginalFilename: "Screenshot Beach Fixture.heic", Availability: "remote", NeedsDownload: true},
 				},
 				Albums: []photos.AlbumMembership{
 					{AlbumID: "fixture-album-1", AlbumTitle: "Beach", AlbumKind: "album:1:2"},
@@ -233,7 +511,7 @@ func fakeSnapshot(changed, includeSecond bool) photos.LibrarySnapshot {
 			Height:           1080,
 			DurationSeconds:  7.5,
 			Resources: []photos.Resource{
-				{Type: "video", UTI: "public.mpeg-4", OriginalFilename: "kitchen-fixture.mp4", Availability: "local", AvailableLocally: true},
+				{SourceIdentifier: "fixture-video", Type: "video", UTI: "public.mpeg-4", OriginalFilename: "kitchen-fixture.mp4", Availability: "local", AvailableLocally: true},
 			},
 			Albums: []photos.AlbumMembership{
 				{AlbumID: "fixture-album-2", AlbumTitle: "Kitchen", AlbumKind: "album:1:2"},

--- a/internal/archive/migrations.go
+++ b/internal/archive/migrations.go
@@ -1,0 +1,203 @@
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/openclaw/crawlkit/store"
+)
+
+func openArchiveStore(ctx context.Context, path string) (*store.Store, error) {
+	db, err := store.Open(ctx, store.Options{Path: path})
+	if err != nil {
+		return nil, err
+	}
+	current, err := db.SchemaVersion(ctx)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("read archive schema version: %w", err)
+	}
+	if current > SchemaVersion {
+		_ = db.Close()
+		return nil, fmt.Errorf("database schema version %d is newer than supported version %d", current, SchemaVersion)
+	}
+	isArchive, err := archiveTablesPresent(ctx, db.DB())
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	empty, err := archiveDatabaseEmpty(ctx, db.DB())
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if !isArchive && (!empty || current != 0) {
+		_ = db.Close()
+		return nil, errors.New("database is not a photoscrawl archive")
+	}
+	if _, err := db.DB().ExecContext(ctx, Schema); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("apply archive schema: %w", err)
+	}
+	if err := migrateArchiveSchema(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+func openArchiveReadOnly(ctx context.Context, path string) (*store.Store, error) {
+	db, err := store.OpenReadOnly(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	current, err := db.SchemaVersion(ctx)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("read archive schema version: %w", err)
+	}
+	if current > SchemaVersion {
+		_ = db.Close()
+		return nil, fmt.Errorf("database schema version %d is newer than supported version %d", current, SchemaVersion)
+	}
+	isArchive, err := archiveTablesPresent(ctx, db.DB())
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if !isArchive {
+		_ = db.Close()
+		return nil, errors.New("database is not a photoscrawl archive")
+	}
+	if current < SchemaVersion {
+		_ = db.Close()
+		return nil, fmt.Errorf("archive schema version %d requires upgrade to %d; run photoscrawl init --db %q", current, SchemaVersion, path)
+	}
+	return db, nil
+}
+
+func archiveTablesPresent(ctx context.Context, db *sql.DB) (bool, error) {
+	var count int
+	if err := db.QueryRowContext(ctx, `
+select count(*)
+from sqlite_master
+where type = 'table' and name in ('asset', 'source_library', 'crawl_snapshot')
+`).Scan(&count); err != nil {
+		return false, fmt.Errorf("inspect archive tables: %w", err)
+	}
+	return count == 3, nil
+}
+
+func archiveDatabaseEmpty(ctx context.Context, db *sql.DB) (bool, error) {
+	var count int
+	if err := db.QueryRowContext(ctx, `select count(*) from sqlite_master where name not like 'sqlite_%'`).Scan(&count); err != nil {
+		return false, fmt.Errorf("inspect archive tables: %w", err)
+	}
+	return count == 0, nil
+}
+
+func migrateArchiveSchema(ctx context.Context, db *store.Store) error {
+	current, err := db.SchemaVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("read archive schema version: %w", err)
+	}
+	if current > SchemaVersion {
+		return fmt.Errorf("database schema version %d is newer than supported version %d", current, SchemaVersion)
+	}
+	if err := db.WithTx(ctx, func(tx *sql.Tx) error {
+		columns := []struct {
+			table      string
+			name       string
+			definition string
+		}{
+			{"asset", "deleted_at", "text"},
+			{"asset", "deletion_source", "text"},
+			{"asset", "deletion_reason", "text"},
+			{"asset_resource", "deleted_at", "text"},
+			{"asset_resource", "deletion_source", "text"},
+			{"asset_resource", "deletion_reason", "text"},
+			{"asset_resource", "source_identifier", "text"},
+		}
+		for _, column := range columns {
+			if err := ensureArchiveColumn(ctx, tx, column.table, column.name, column.definition); err != nil {
+				return err
+			}
+		}
+		for _, statement := range []string{
+			`create index if not exists asset_deleted_idx on asset(deleted_at)`,
+			`create index if not exists resource_deleted_idx on asset_resource(deleted_at)`,
+			`create index if not exists resource_source_identifier_idx on asset_resource(asset_id, source_identifier)`,
+		} {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("create tombstone index: %w", err)
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `
+update asset
+set deletion_source = coalesce(nullif(deletion_source, ''), 'unknown'),
+    deletion_reason = coalesce(nullif(deletion_reason, ''), 'legacy_asset_tombstone')
+where deleted_at is not null
+`); err != nil {
+			return fmt.Errorf("normalize asset tombstones: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+update asset_resource
+set deleted_at = coalesce(deleted_at, (select deleted_at from asset where asset.id = asset_resource.asset_id)),
+    deletion_source = coalesce(nullif(deletion_source, ''), (select deletion_source from asset where asset.id = asset_resource.asset_id), 'unknown'),
+    deletion_reason = coalesce(nullif(deletion_reason, ''), 'parent_asset_deleted')
+where exists (select 1 from asset where asset.id = asset_resource.asset_id and asset.deleted_at is not null)
+`); err != nil {
+			return fmt.Errorf("reconcile asset resource tombstones: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+update asset_resource
+set deletion_source = coalesce(nullif(deletion_source, ''), 'unknown'),
+    deletion_reason = coalesce(nullif(deletion_reason, ''), 'legacy_resource_tombstone')
+where deleted_at is not null
+`); err != nil {
+			return fmt.Errorf("normalize asset resource tombstones: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("migrate archive schema: %w", err)
+	}
+	if err := db.EnsureSchemaVersion(ctx, SchemaVersion); err != nil {
+		return fmt.Errorf("write archive schema version: %w", err)
+	}
+	return nil
+}
+
+func ensureArchiveColumn(ctx context.Context, tx *sql.Tx, table, name, definition string) error {
+	rows, err := tx.QueryContext(ctx, "pragma table_info("+store.QuoteIdent(table)+")")
+	if err != nil {
+		return fmt.Errorf("inspect %s columns: %w", table, err)
+	}
+	found := false
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var columnName, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &columnName, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan %s columns: %w", table, err)
+		}
+		if columnName == name {
+			found = true
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if found {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, "alter table "+store.QuoteIdent(table)+" add column "+store.QuoteIdent(name)+" "+definition); err != nil {
+		return fmt.Errorf("add %s.%s: %w", table, name, err)
+	}
+	return nil
+}

--- a/internal/archive/migrations_test.go
+++ b/internal/archive/migrations_test.go
@@ -1,0 +1,187 @@
+package archive
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/crawlkit/store"
+	"github.com/openclaw/photoscrawl/internal/photos"
+)
+
+const schemaV1Fixture = `
+create table source_library (
+  id text primary key, library_path text not null, snapshot_path text not null,
+  snapshot_created_at text not null, photos_version text not null, metadata_json text not null
+);
+create table crawl_snapshot (
+  id text primary key, source_library_id text not null references source_library(id),
+  started_at text not null, completed_at text not null, provider text not null,
+  asset_count integer not null, resource_count integer not null,
+  album_membership_count integer not null, location_count integer not null,
+  metadata_json text not null
+);
+create table asset (
+  id text primary key, local_identifier text not null unique, media_type text not null,
+  media_subtypes text not null, creation_date text not null, modification_date text not null,
+  added_date text not null, timezone_name text not null, width integer not null,
+  height integer not null, duration_seconds real not null, favorite integer not null,
+  hidden integer not null, burst_identifier text not null, represents_burst integer not null,
+  source_library_id text not null references source_library(id), metadata_json text not null
+);
+create table asset_resource (
+  id text primary key, asset_id text not null references asset(id), resource_type text not null,
+  uti text not null, original_filename text not null, local_path text not null,
+  file_size integer not null, sha256 text not null, available_locally integer not null,
+  needs_download integer not null
+);
+`
+
+func TestSchemaV2MigrationPreservesV1AssetRows(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "photos.sqlite")
+	legacy, err := store.Open(ctx, store.Options{Path: dbPath, Schema: schemaV1Fixture, SchemaVersion: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.DB().ExecContext(ctx, `
+insert into source_library values ('library-1', '/fixture', 'snapshot', '2026-07-18T00:00:00Z', 'fixture', '{}');
+insert into asset values ('asset-1', 'local-1', 'image', '', '2026-07-18T00:00:00Z', '2026-07-18T00:00:00Z', '', '', 10, 20, 0, 0, 0, '', 0, 'library-1', '{"kept":true}');
+insert into asset_resource values ('resource-1', 'asset-1', 'thumbnail', 'public.jpeg', 'thumb.jpg', '/tmp/thumb.jpg', 42, 'hash', 1, 0);
+`); err != nil {
+		legacy.Close()
+		t.Fatal(err)
+	}
+	var assetRowID, resourceRowID int64
+	if err := legacy.DB().QueryRowContext(ctx, `select rowid from asset where id = 'asset-1'`).Scan(&assetRowID); err != nil {
+		legacy.Close()
+		t.Fatal(err)
+	}
+	if err := legacy.DB().QueryRowContext(ctx, `select rowid from asset_resource where id = 'resource-1'`).Scan(&resourceRowID); err != nil {
+		legacy.Close()
+		t.Fatal(err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := openArchiveReadOnly(ctx, dbPath); err == nil || !strings.Contains(err.Error(), "requires upgrade") {
+		t.Fatalf("read-only v1 open error = %v, want upgrade-required error", err)
+	}
+	unchanged, err := store.OpenReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unchangedVersion, err := unchanged.SchemaVersion(ctx)
+	if err != nil {
+		unchanged.Close()
+		t.Fatal(err)
+	}
+	if err := unchanged.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if unchangedVersion != 1 {
+		t.Fatalf("read-only open changed schema version to %d", unchangedVersion)
+	}
+
+	migrated, err := openArchiveStore(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer migrated.Close()
+	version, err := migrated.SchemaVersion(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != SchemaVersion {
+		t.Fatalf("schema version = %d, want %d", version, SchemaVersion)
+	}
+	var gotAssetRowID, gotResourceRowID int64
+	var metadata string
+	var assetDeleted, resourceDeleted any
+	if err := migrated.DB().QueryRowContext(ctx, `select rowid, metadata_json, deleted_at from asset where id = 'asset-1'`).Scan(&gotAssetRowID, &metadata, &assetDeleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrated.DB().QueryRowContext(ctx, `select rowid, deleted_at from asset_resource where id = 'resource-1'`).Scan(&gotResourceRowID, &resourceDeleted); err != nil {
+		t.Fatal(err)
+	}
+	if gotAssetRowID != assetRowID || gotResourceRowID != resourceRowID || metadata != `{"kept":true}` {
+		t.Fatalf("migration changed rows: asset rowid %d/%d resource rowid %d/%d metadata %q", gotAssetRowID, assetRowID, gotResourceRowID, resourceRowID, metadata)
+	}
+	if assetDeleted != nil || resourceDeleted != nil {
+		t.Fatalf("migration invented tombstones: asset=%v resource=%v", assetDeleted, resourceDeleted)
+	}
+}
+
+func TestSchemaV2CrawlAdoptsExactLegacyResourceRows(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	paths := testPaths(t)
+	libraryPath := filepath.Join(t.TempDir(), "Fixture Photos Library.photoslibrary")
+	if err := os.MkdirAll(libraryPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sourceID := stableID("source_library", libraryPath)
+	assetID := stableID("asset", sourceID, "fixture-asset-1")
+	resource := photos.Resource{Type: "photo", UTI: "public.heic", OriginalFilename: "same.heic", Availability: "local", AvailableLocally: true}
+	legacyIDs := []string{
+		stableID("asset_resource", assetID, fmt.Sprintf("%06d", 0), resource.Type, resource.UTI, resource.OriginalFilename),
+		stableID("asset_resource", assetID, fmt.Sprintf("%06d", 1), resource.Type, resource.UTI, resource.OriginalFilename),
+	}
+	legacy, err := store.Open(ctx, store.Options{Path: paths.Database, Schema: schemaV1Fixture, SchemaVersion: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	statements := []struct {
+		query string
+		args  []any
+	}{
+		{`insert into source_library values (?, ?, 'snapshot', '2026-07-18T00:00:00Z', 'fixture', '{}')`, []any{sourceID, libraryPath}},
+		{`insert into asset values (?, 'fixture-asset-1', 'image', '', '2026-07-18T00:00:00Z', '2026-07-18T00:00:00Z', '', '', 10, 20, 0, 0, 0, '', 0, ?, '{}')`, []any{assetID, sourceID}},
+		{`insert into asset_resource values (?, ?, 'photo', 'public.heic', 'same.heic', '/tmp/first.heic', 10, 'first-hash', 1, 0)`, []any{legacyIDs[0], assetID}},
+		{`insert into asset_resource values (?, ?, 'photo', 'public.heic', 'same.heic', '/tmp/second.heic', 20, 'second-hash', 1, 0)`, []any{legacyIDs[1], assetID}},
+	}
+	for _, statement := range statements {
+		if _, err := legacy.DB().ExecContext(ctx, statement.query, statement.args...); err != nil {
+			legacy.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := fakeSnapshot(false, false)
+	snapshot.Assets[0].Resources = []photos.Resource{
+		{SourceIdentifier: "canonical-first", Type: resource.Type, UTI: resource.UTI, OriginalFilename: resource.OriginalFilename, LocalPath: "/tmp/first.heic", StableHash: "first-hash", Availability: "local", AvailableLocally: true},
+		{SourceIdentifier: "canonical-second", Type: resource.Type, UTI: resource.UTI, OriginalFilename: resource.OriginalFilename, LocalPath: "/tmp/second.heic", StableHash: "second-hash", Availability: "local", AvailableLocally: true},
+	}
+	if _, err := Crawl(ctx, paths, CrawlOptions{LibraryPath: libraryPath, Provider: fakeProvider{snapshot: snapshot}, Now: fixedClock("2026-07-18T12:00:00Z")}); err != nil {
+		t.Fatal(err)
+	}
+	migrated, err := openArchiveReadOnly(ctx, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer migrated.Close()
+	for index, sourceIdentifier := range []string{"canonical-first", "canonical-second"} {
+		var gotID, gotHash string
+		if err := migrated.DB().QueryRowContext(ctx, `select id, sha256 from asset_resource where source_identifier = ?`, sourceIdentifier).Scan(&gotID, &gotHash); err != nil {
+			t.Fatal(err)
+		}
+		if gotID != legacyIDs[index] || gotHash != []string{"first-hash", "second-hash"}[index] {
+			t.Fatalf("resource %s adopted id/hash %q/%q, want %q", sourceIdentifier, gotID, gotHash, legacyIDs[index])
+		}
+	}
+	var resourceRows int
+	if err := migrated.DB().QueryRowContext(ctx, `select count(*) from asset_resource`).Scan(&resourceRows); err != nil {
+		t.Fatal(err)
+	}
+	if resourceRows != 2 {
+		t.Fatalf("resource rows = %d, want 2", resourceRows)
+	}
+}

--- a/internal/archive/neighbors.go
+++ b/internal/archive/neighbors.go
@@ -8,8 +8,6 @@ import (
 	"math"
 	"sort"
 	"strings"
-
-	"github.com/openclaw/crawlkit/store"
 )
 
 const (
@@ -65,13 +63,13 @@ func Neighbors(ctx context.Context, paths Paths, opts NeighborOptions) (Neighbor
 		limit = 100
 	}
 
-	db, err := store.OpenReadOnly(ctx, paths.Database)
+	db, err := openArchiveReadOnly(ctx, paths.Database)
 	if err != nil {
 		return NeighborResult{}, err
 	}
 	defer db.Close()
 
-	if _, err := oneRow(ctx, db.DB(), `select id from asset where id = ?`, id); errors.Is(err, sql.ErrNoRows) {
+	if _, err := oneRow(ctx, db.DB(), `select id from asset where id = ? and deleted_at is null`, id); errors.Is(err, sql.ErrNoRows) {
 		return NeighborResult{}, fmt.Errorf("asset not found: %s", id)
 	} else if err != nil {
 		return NeighborResult{}, err
@@ -122,7 +120,7 @@ from asset source
 join asset target on target.burst_identifier = source.burst_identifier and target.id <> source.id
 left join evidence_ref source_evidence on source_evidence.asset_id = source.id and source_evidence.evidence_kind = 'asset_metadata'
 left join evidence_ref target_evidence on target_evidence.asset_id = target.id and target_evidence.evidence_kind = 'asset_metadata'
-where source.id = ? and trim(source.burst_identifier) <> ''
+where source.id = ? and source.deleted_at is null and target.deleted_at is null and trim(source.burst_identifier) <> ''
 order by target.creation_date, target.id
 limit ?
 `, id, limit)
@@ -159,7 +157,7 @@ join album_membership target_membership on target_membership.album_id = source_m
 join asset target on target.id = target_membership.asset_id
 left join evidence_ref source_evidence on source_evidence.asset_id = source_membership.asset_id and source_evidence.evidence_kind = 'album_membership' and source_evidence.pointer = 'album:' || source_membership.album_id
 left join evidence_ref target_evidence on target_evidence.asset_id = target_membership.asset_id and target_evidence.evidence_kind = 'album_membership' and target_evidence.pointer = 'album:' || target_membership.album_id
-where source_membership.asset_id = ?
+where source_membership.asset_id = ? and target.deleted_at is null
 order by target.creation_date, target.id
 limit ?
 `, id, limit)
@@ -195,7 +193,11 @@ select distinct target.id, target.media_type, target.creation_date, target_resou
 from asset_resource source_resource
 join asset_resource target_resource on target_resource.sha256 = source_resource.sha256 and target_resource.asset_id <> source_resource.asset_id
 join asset target on target.id = target_resource.asset_id
-where source_resource.asset_id = ? and trim(source_resource.sha256) <> ''
+where source_resource.asset_id = ?
+  and source_resource.deleted_at is null
+  and target_resource.deleted_at is null
+  and target.deleted_at is null
+  and trim(source_resource.sha256) <> ''
 order by target.creation_date, target.id
 limit ?
 `, id, limit)
@@ -233,6 +235,8 @@ join asset target on target.id <> source.id
 left join evidence_ref source_evidence on source_evidence.asset_id = source.id and source_evidence.evidence_kind = 'asset_metadata'
 left join evidence_ref target_evidence on target_evidence.asset_id = target.id and target_evidence.evidence_kind = 'asset_metadata'
 where source.id = ?
+  and source.deleted_at is null
+  and target.deleted_at is null
   and trim(source.creation_date) <> ''
   and trim(target.creation_date) <> ''
   and `+delta+` <= ?
@@ -274,6 +278,7 @@ from location_observation source_location
 join location_observation target_location on target_location.asset_id <> source_location.asset_id
 join asset target on target.id = target_location.asset_id
 where source_location.asset_id = ?
+  and target.deleted_at is null
   and abs(target_location.latitude - source_location.latitude) <= ?
   and abs(target_location.longitude - source_location.longitude) <= ?
 order by latitude_delta + longitude_delta, target.creation_date, target.id
@@ -320,6 +325,7 @@ join visual_observation target_observation on target_observation.observation_typ
   and target_observation.asset_id <> source_observation.asset_id
 join asset target on target.id = target_observation.asset_id
 where source_observation.asset_id = ?
+  and target.deleted_at is null
   and source_observation.observation_type = 'document_signal'
 order by shared_confidence desc, target.creation_date, target.id
 limit ?

--- a/internal/archive/neighbors_test.go
+++ b/internal/archive/neighbors_test.go
@@ -93,7 +93,7 @@ func fakeNeighborSnapshot() photos.LibrarySnapshot {
 					HorizontalAccuracy: &accuracy,
 				},
 				Resources: []photos.Resource{
-					{Type: "photo", UTI: "public.heic", OriginalFilename: "Screenshot Neighbor One.heic", Availability: "local", StableHash: "same-fixture-resource-hash", AvailableLocally: true},
+					{SourceIdentifier: "neighbor-one-photo", Type: "photo", UTI: "public.heic", OriginalFilename: "Screenshot Neighbor One.heic", Availability: "local", StableHash: "same-fixture-resource-hash", AvailableLocally: true},
 				},
 				Albums: []photos.AlbumMembership{
 					{AlbumID: "fixture-shared-album", AlbumTitle: "Shared Fixture Album", AlbumKind: "album:fixture"},
@@ -117,7 +117,7 @@ func fakeNeighborSnapshot() photos.LibrarySnapshot {
 					HorizontalAccuracy: &accuracy,
 				},
 				Resources: []photos.Resource{
-					{Type: "photo", UTI: "public.heic", OriginalFilename: "Screenshot Neighbor Two.heic", Availability: "local", StableHash: "same-fixture-resource-hash", AvailableLocally: true},
+					{SourceIdentifier: "neighbor-two-photo", Type: "photo", UTI: "public.heic", OriginalFilename: "Screenshot Neighbor Two.heic", Availability: "local", StableHash: "same-fixture-resource-hash", AvailableLocally: true},
 				},
 				Albums: []photos.AlbumMembership{
 					{AlbumID: "fixture-shared-album", AlbumTitle: "Shared Fixture Album", AlbumKind: "album:fixture"},

--- a/internal/archive/query.go
+++ b/internal/archive/query.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/openclaw/crawlkit/store"
 )
 
 type SearchOptions struct {
@@ -62,7 +60,7 @@ func Search(ctx context.Context, paths Paths, opts SearchOptions) (SearchResult,
 	if limit > 100 {
 		limit = 100
 	}
-	db, err := store.OpenReadOnly(ctx, paths.Database)
+	db, err := openArchiveReadOnly(ctx, paths.Database)
 	if err != nil {
 		return SearchResult{}, err
 	}
@@ -74,7 +72,7 @@ select asset.id, asset.media_type, asset.creation_date, asset_fts.title,
        snippet(asset_fts, 2, '[', ']', ' ... ', 12) as snippet
 from asset_fts
 join asset on asset.id = asset_fts.id
-where asset_fts match ?
+where asset_fts match ? and asset.deleted_at is null
 order by rank
 limit ?
 `, fts, limit)
@@ -103,7 +101,7 @@ select asset.id, observation_fts.id, asset.media_type, asset.creation_date, obse
        snippet(observation_fts, 3, '[', ']', ' ... ', 12) as snippet
 from observation_fts
 join asset on asset.id = observation_fts.asset_id
-where observation_fts match ?
+where observation_fts match ? and asset.deleted_at is null
 order by rank
 limit ?
 `, fts, observationLimit)
@@ -131,7 +129,7 @@ func Open(ctx context.Context, paths Paths, rowID string) (OpenResult, error) {
 	if rowID == "" {
 		return OpenResult{}, errors.New("id is required")
 	}
-	db, err := store.OpenReadOnly(ctx, paths.Database)
+	db, err := openArchiveReadOnly(ctx, paths.Database)
 	if err != nil {
 		return OpenResult{}, err
 	}
@@ -140,7 +138,7 @@ func Open(ctx context.Context, paths Paths, rowID string) (OpenResult, error) {
 	asset, err := oneRow(ctx, db.DB(), `
 select id, local_identifier, media_type, media_subtypes, creation_date, modification_date, added_date,
        timezone_name, width, height, duration_seconds, favorite, hidden, burst_identifier,
-       represents_burst, source_library_id, metadata_json
+       represents_burst, source_library_id, metadata_json, deleted_at, deletion_source, deletion_reason
 from asset
 where id = ?
 `, rowID)
@@ -151,7 +149,8 @@ where id = ?
 		return OpenResult{}, err
 	}
 	resources, err := rows(ctx, db.DB(), `
-select id, resource_type, uti, original_filename, local_path, file_size, sha256, available_locally, needs_download
+select id, source_identifier, resource_type, uti, original_filename, local_path, file_size, sha256, available_locally, needs_download,
+       deleted_at, deletion_source, deletion_reason
 from asset_resource
 where asset_id = ?
 order by resource_type, original_filename
@@ -254,7 +253,7 @@ func Evidence(ctx context.Context, paths Paths, rowID string) (EvidenceResult, e
 	if rowID == "" {
 		return EvidenceResult{}, errors.New("row id is required")
 	}
-	db, err := store.OpenReadOnly(ctx, paths.Database)
+	db, err := openArchiveReadOnly(ctx, paths.Database)
 	if err != nil {
 		return EvidenceResult{}, err
 	}

--- a/internal/archive/schema.go
+++ b/internal/archive/schema.go
@@ -1,6 +1,6 @@
 package archive
 
-const SchemaVersion = 1
+const SchemaVersion = 2
 
 const Schema = `
 create table if not exists source_library (
@@ -71,12 +71,16 @@ create table if not exists asset (
   burst_identifier text not null,
   represents_burst integer not null,
   source_library_id text not null references source_library(id),
-  metadata_json text not null
+  metadata_json text not null,
+  deleted_at text,
+  deletion_source text,
+  deletion_reason text
 );
 
 create table if not exists asset_resource (
   id text primary key,
   asset_id text not null references asset(id),
+  source_identifier text not null,
   resource_type text not null,
   uti text not null,
   original_filename text not null,
@@ -84,7 +88,10 @@ create table if not exists asset_resource (
   file_size integer not null,
   sha256 text not null,
   available_locally integer not null,
-  needs_download integer not null
+  needs_download integer not null,
+  deleted_at text,
+  deletion_source text,
+  deletion_reason text
 );
 
 create table if not exists album_membership (

--- a/internal/photos/fallback.go
+++ b/internal/photos/fallback.go
@@ -3,7 +3,19 @@ package photos
 import (
 	"context"
 	"fmt"
+	"strings"
 )
+
+func ProviderByName(name string) (Provider, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "auto":
+		return NewProvider(), nil
+	case "sqlite":
+		return SQLiteSnapshotProvider{}, nil
+	default:
+		return nil, fmt.Errorf("unknown photos provider %q (want auto or sqlite)", name)
+	}
+}
 
 type FallbackProvider struct {
 	Primary   Provider

--- a/internal/photos/local_media.go
+++ b/internal/photos/local_media.go
@@ -70,6 +70,7 @@ func AttachLocalMediaPaths(snapshot *LibrarySnapshot, libraryPath string) error 
 		}
 		if !assigned && asset.MediaType == "image" {
 			asset.Resources = append(asset.Resources, Resource{
+				SourceIdentifier: "photos_library_package:" + candidate.Class,
 				Type:             "local_" + candidate.Class,
 				UTI:              utiForPath(candidate.Path),
 				OriginalFilename: filepath.Base(candidate.Path),

--- a/internal/photos/local_media_test.go
+++ b/internal/photos/local_media_test.go
@@ -67,4 +67,7 @@ func TestAttachLocalMediaPathsAddsSyntheticResource(t *testing.T) {
 	if resource.Type != "local_original" || resource.LocalPath != originalPath || !resource.AvailableLocally {
 		t.Fatalf("resource = %#v", resource)
 	}
+	if resource.SourceIdentifier != "photos_library_package:original" {
+		t.Fatalf("source identifier = %q", resource.SourceIdentifier)
+	}
 }

--- a/internal/photos/photokit_bridge_darwin.m
+++ b/internal/photos/photokit_bridge_darwin.m
@@ -189,6 +189,7 @@ static NSArray *pcResources(PHAsset *asset) {
   NSMutableArray *out = [NSMutableArray array];
   for (PHAssetResource *resource in [PHAssetResource assetResourcesForAsset:asset]) {
     NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+    entry[@"source_identifier"] = [NSString stringWithFormat:@"photokit_resource_type:%ld", (long)resource.type];
     entry[@"type"] = pcResourceType(resource.type);
     entry[@"uti"] = pcString(resource.uniformTypeIdentifier);
     entry[@"original_filename"] = pcString(resource.originalFilename);

--- a/internal/photos/sqlite_snapshot.go
+++ b/internal/photos/sqlite_snapshot.go
@@ -53,7 +53,15 @@ func (SQLiteSnapshotProvider) Snapshot(ctx context.Context, libraryPath string) 
 }
 
 func sqliteAssets(ctx context.Context, db *sql.DB, resources map[int64][]Resource, albums map[int64][]AlbumMembership) ([]Asset, error) {
-	rows, err := db.QueryContext(ctx, `
+	trashDateExpression := "null"
+	hasTrashDate, err := sqliteColumnExists(ctx, db, "ZASSET", "ZTRASHEDDATE")
+	if err != nil {
+		return nil, err
+	}
+	if hasTrashDate {
+		trashDateExpression = "cast(a.ZTRASHEDDATE as real)"
+	}
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(`
 select a.Z_PK,
        coalesce(a.ZUUID, ''),
        coalesce(a.ZKIND, -1),
@@ -68,18 +76,19 @@ select a.Z_PK,
        coalesce(a.ZFAVORITE, 0),
        coalesce(a.ZHIDDEN, 0),
        coalesce(a.ZAVALANCHEUUID, ''),
-       cast(a.ZLATITUDE as real),
-       cast(a.ZLONGITUDE as real),
-       cast(aa.ZGPSHORIZONTALACCURACY as real),
+	       cast(a.ZLATITUDE as real),
+	       cast(a.ZLONGITUDE as real),
+	       cast(aa.ZGPSHORIZONTALACCURACY as real),
        coalesce(a.ZUNIFORMTYPEIDENTIFIER, ''),
        coalesce(a.ZFILENAME, ''),
-       coalesce(aa.ZORIGINALFILENAME, '')
+       coalesce(aa.ZORIGINALFILENAME, ''),
+       coalesce(a.ZTRASHEDSTATE, 0),
+       %s
 from ZASSET a
 left join ZADDITIONALASSETATTRIBUTES aa on aa.ZASSET = a.Z_PK
-where coalesce(a.ZTRASHEDSTATE, 0) = 0
-  and coalesce(a.ZUUID, '') <> ''
+where coalesce(a.ZUUID, '') <> ''
 order by a.ZDATECREATED, a.ZUUID
-`)
+`, trashDateExpression))
 	if err != nil {
 		return nil, fmt.Errorf("query sqlite assets: %w", err)
 	}
@@ -109,6 +118,8 @@ order by a.ZDATECREATED, a.ZUUID
 			&row.uti,
 			&row.filename,
 			&row.originalFilename,
+			&row.trashedState,
+			&row.trashedDate,
 		); err != nil {
 			return nil, err
 		}
@@ -148,6 +159,16 @@ order by a.ZDATECREATED, a.ZUUID
 				HorizontalAccuracy: accuracy,
 			}
 		}
+		if row.trashedState != 0 {
+			asset.DeletedAt = coreDataTime(row.trashedDate)
+			asset.DeletionSource = "photos_sqlite_snapshot"
+			asset.DeletionReason = "trashed_in_photos_library"
+			if asset.DeletedAt == "" {
+				asset.Metadata["deletion_timestamp_source"] = "crawl_observed_at"
+			} else {
+				asset.Metadata["deletion_timestamp_source"] = "ZTRASHEDDATE"
+			}
+		}
 		assets = append(assets, asset)
 	}
 	if err := rows.Err(); err != nil {
@@ -158,7 +179,8 @@ order by a.ZDATECREATED, a.ZUUID
 
 func sqliteResources(ctx context.Context, db *sql.DB) (map[int64][]Resource, error) {
 	rows, err := db.QueryContext(ctx, `
-select r.ZASSET,
+select r.Z_PK,
+       r.ZASSET,
        coalesce(r.ZRESOURCETYPE, -1),
        coalesce(r.ZCOMPACTUTI, a.ZUNIFORMTYPEIDENTIFIER, ''),
        coalesce(aa.ZORIGINALFILENAME, a.ZFILENAME, ''),
@@ -180,14 +202,15 @@ order by r.ZASSET, r.ZRESOURCETYPE, r.ZVERSION
 
 	out := map[int64][]Resource{}
 	for rows.Next() {
-		var assetPK, resourceType, fileSize, localAvailability, remoteAvailability, version int64
+		var resourcePK, assetPK, resourceType, fileSize, localAvailability, remoteAvailability, version int64
 		var uti, originalFilename, stableHash string
-		if err := rows.Scan(&assetPK, &resourceType, &uti, &originalFilename, &fileSize, &stableHash, &localAvailability, &remoteAvailability, &version); err != nil {
+		if err := rows.Scan(&resourcePK, &assetPK, &resourceType, &uti, &originalFilename, &fileSize, &stableHash, &localAvailability, &remoteAvailability, &version); err != nil {
 			return nil, err
 		}
 		availableLocally := localAvailability > 0
 		needsDownload := !availableLocally && remoteAvailability > 0
 		out[assetPK] = append(out[assetPK], Resource{
+			SourceIdentifier: fmt.Sprintf("sqlite_internal_resource:%d", resourcePK),
 			Type:             fmt.Sprintf("internal_resource:%d", resourceType),
 			UTI:              uti,
 			OriginalFilename: originalFilename,
@@ -268,6 +291,28 @@ type sqliteAssetRow struct {
 	uti                string
 	filename           string
 	originalFilename   string
+	trashedState       int64
+	trashedDate        sql.NullFloat64
+}
+
+func sqliteColumnExists(ctx context.Context, db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.QueryContext(ctx, "pragma table_info("+store.QuoteIdent(table)+")")
+	if err != nil {
+		return false, fmt.Errorf("inspect sqlite table %s: %w", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 func sqliteMediaType(kind int64) string {

--- a/internal/photos/sqlite_snapshot_test.go
+++ b/internal/photos/sqlite_snapshot_test.go
@@ -35,8 +35,8 @@ func TestSQLiteSnapshotProviderReadsSyntheticLibrary(t *testing.T) {
 	if snapshot.Provider != "photos_sqlite_snapshot" {
 		t.Fatalf("provider = %q", snapshot.Provider)
 	}
-	if len(snapshot.Assets) != 1 {
-		t.Fatalf("assets = %d, want 1", len(snapshot.Assets))
+	if len(snapshot.Assets) != 2 {
+		t.Fatalf("assets = %d, want 2", len(snapshot.Assets))
 	}
 	asset := snapshot.Assets[0]
 	if asset.MediaType != "image" || asset.CreationDate != "2026-05-28T10:00:00Z" {
@@ -48,8 +48,15 @@ func TestSQLiteSnapshotProviderReadsSyntheticLibrary(t *testing.T) {
 	if len(asset.Resources) != 1 || !asset.Resources[0].NeedsDownload || asset.Resources[0].Availability != "remote" {
 		t.Fatalf("resources = %#v", asset.Resources)
 	}
+	if asset.Resources[0].SourceIdentifier != "sqlite_internal_resource:100" {
+		t.Fatalf("resource source identifier = %q", asset.Resources[0].SourceIdentifier)
+	}
 	if len(asset.Albums) != 1 || asset.Albums[0].AlbumTitle != "Synthetic Album" {
 		t.Fatalf("albums = %#v", asset.Albums)
+	}
+	deleted := snapshot.Assets[1]
+	if deleted.DeletedAt != "2026-05-28T11:00:00Z" || deleted.DeletionSource != "photos_sqlite_snapshot" || deleted.DeletionReason != "trashed_in_photos_library" {
+		t.Fatalf("deleted asset tombstone = %#v", deleted)
 	}
 }
 
@@ -65,6 +72,56 @@ func TestFallbackProviderUsesSecondaryAfterPrimaryError(t *testing.T) {
 	}
 	if snapshot.Provider != "secondary" || snapshot.Metadata["source_strategy"] != "fallback_after_primary_error" {
 		t.Fatalf("snapshot = %#v", snapshot)
+	}
+}
+
+func TestSQLiteSnapshotProviderMarksMissingTrashDateForObservedAtFallback(t *testing.T) {
+	t.Parallel()
+	libraryPath := filepath.Join(t.TempDir(), "Fixture Photos Library.photoslibrary")
+	dbPath := filepath.Join(libraryPath, "database", "Photos.sqlite")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.Open(context.Background(), store.Options{Path: dbPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := createSyntheticPhotosDB(db.DB()); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.DB().Exec(`alter table ZASSET drop column ZTRASHEDDATE`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.DB().Exec(`update ZASSET set ZTRASHEDSTATE = 1 where Z_PK = 1`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := SQLiteSnapshotProvider{}.Snapshot(context.Background(), libraryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	asset := snapshot.Assets[0]
+	if asset.DeletedAt != "" || asset.DeletionReason != "trashed_in_photos_library" || asset.Metadata["deletion_timestamp_source"] != "crawl_observed_at" {
+		t.Fatalf("fallback tombstone = %#v", asset)
+	}
+}
+
+func TestProviderByNameSelectsSQLiteForScratchLibraries(t *testing.T) {
+	t.Parallel()
+	provider, err := ProviderByName("sqlite")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := provider.(SQLiteSnapshotProvider); !ok {
+		t.Fatalf("provider = %T, want SQLiteSnapshotProvider", provider)
+	}
+	if _, err := ProviderByName("unknown"); err == nil {
+		t.Fatal("unknown provider should fail")
 	}
 }
 
@@ -99,9 +156,10 @@ func createSyntheticPhotosDB(db *sql.DB) error {
 			ZAVALANCHEUUID varchar,
 			ZLATITUDE float,
 			ZLONGITUDE float,
-			ZUNIFORMTYPEIDENTIFIER varchar,
-			ZFILENAME varchar,
-			ZTRASHEDSTATE integer
+				ZUNIFORMTYPEIDENTIFIER varchar,
+				ZFILENAME varchar,
+				ZTRASHEDSTATE integer,
+				ZTRASHEDDATE timestamp
 		)`,
 		`create table ZADDITIONALASSETATTRIBUTES (
 			ZASSET integer,
@@ -110,7 +168,8 @@ func createSyntheticPhotosDB(db *sql.DB) error {
 			ZORIGINALFILENAME varchar
 		)`,
 		`create table ZINTERNALRESOURCE (
-			ZASSET integer,
+				Z_PK integer primary key,
+				ZASSET integer,
 			ZRESOURCETYPE integer,
 			ZCOMPACTUTI varchar,
 			ZDATALENGTH integer,
@@ -140,15 +199,22 @@ func createSyntheticPhotosDB(db *sql.DB) error {
 	}
 	created := coreDataSeconds("2026-05-28T10:00:00Z")
 	if _, err := db.Exec(`
-insert into ZASSET(Z_PK, ZUUID, ZKIND, ZKINDSUBTYPE, ZDATECREATED, ZMODIFICATIONDATE, ZADDEDDATE, ZWIDTH, ZHEIGHT, ZDURATION, ZFAVORITE, ZHIDDEN, ZAVALANCHEUUID, ZLATITUDE, ZLONGITUDE, ZUNIFORMTYPEIDENTIFIER, ZFILENAME, ZTRASHEDSTATE)
-values (1, 'fixture-uuid-1', 0, 0, ?, ?, ?, 4032, 3024, 0, 1, 0, '', 52.3676, 4.9041, 'public.heic', 'synthetic.heic', 0)
-`, created, created, created); err != nil {
+	insert into ZASSET(Z_PK, ZUUID, ZKIND, ZKINDSUBTYPE, ZDATECREATED, ZMODIFICATIONDATE, ZADDEDDATE, ZWIDTH, ZHEIGHT, ZDURATION, ZFAVORITE, ZHIDDEN, ZAVALANCHEUUID, ZLATITUDE, ZLONGITUDE, ZUNIFORMTYPEIDENTIFIER, ZFILENAME, ZTRASHEDSTATE, ZTRASHEDDATE)
+	values (1, 'fixture-uuid-1', 0, 0, ?, ?, ?, 4032, 3024, 0, 1, 0, '', 52.3676, 4.9041, 'public.heic', 'synthetic.heic', 0, null)
+	`, created, created, created); err != nil {
+		return err
+	}
+	deleted := coreDataSeconds("2026-05-28T11:00:00Z")
+	if _, err := db.Exec(`
+	insert into ZASSET(Z_PK, ZUUID, ZKIND, ZKINDSUBTYPE, ZDATECREATED, ZMODIFICATIONDATE, ZADDEDDATE, ZWIDTH, ZHEIGHT, ZDURATION, ZFAVORITE, ZHIDDEN, ZAVALANCHEUUID, ZLATITUDE, ZLONGITUDE, ZUNIFORMTYPEIDENTIFIER, ZFILENAME, ZTRASHEDSTATE, ZTRASHEDDATE)
+	values (2, 'fixture-uuid-deleted', 0, 0, ?, ?, ?, 1024, 768, 0, 0, 0, '', 0, 0, 'public.jpeg', 'deleted.jpeg', 1, ?)
+	`, created, created, created, deleted); err != nil {
 		return err
 	}
 	if _, err := db.Exec(`insert into ZADDITIONALASSETATTRIBUTES(ZASSET, ZTIMEZONENAME, ZGPSHORIZONTALACCURACY, ZORIGINALFILENAME) values (1, 'Europe/Amsterdam', 8.25, 'synthetic.heic')`); err != nil {
 		return err
 	}
-	if _, err := db.Exec(`insert into ZINTERNALRESOURCE(ZASSET, ZRESOURCETYPE, ZCOMPACTUTI, ZDATALENGTH, ZSTABLEHASH, ZFINGERPRINT, ZLOCALAVAILABILITY, ZREMOTEAVAILABILITY, ZVERSION) values (1, 0, 'public.heic', 12345, 'stable-hash', '', 0, 1, 1)`); err != nil {
+	if _, err := db.Exec(`insert into ZINTERNALRESOURCE(Z_PK, ZASSET, ZRESOURCETYPE, ZCOMPACTUTI, ZDATALENGTH, ZSTABLEHASH, ZFINGERPRINT, ZLOCALAVAILABILITY, ZREMOTEAVAILABILITY, ZVERSION) values (100, 1, 0, 'public.heic', 12345, 'stable-hash', '', 0, 1, 1)`); err != nil {
 		return err
 	}
 	if _, err := db.Exec(`insert into ZGENERICALBUM(Z_PK, ZUUID, ZTITLE, ZKIND, ZCLOUDALBUMSUBTYPE, ZTRASHEDSTATE) values (10, 'album-uuid-1', 'Synthetic Album', 2, 0, 0)`); err != nil {

--- a/internal/photos/types.go
+++ b/internal/photos/types.go
@@ -30,6 +30,9 @@ type Asset struct {
 	Hidden           bool              `json:"hidden"`
 	BurstIdentifier  string            `json:"burst_identifier"`
 	RepresentsBurst  bool              `json:"represents_burst"`
+	DeletedAt        string            `json:"deleted_at,omitempty"`
+	DeletionSource   string            `json:"deletion_source,omitempty"`
+	DeletionReason   string            `json:"deletion_reason,omitempty"`
 	Location         *Location         `json:"location,omitempty"`
 	Resources        []Resource        `json:"resources,omitempty"`
 	Albums           []AlbumMembership `json:"albums,omitempty"`
@@ -37,6 +40,7 @@ type Asset struct {
 }
 
 type Resource struct {
+	SourceIdentifier string         `json:"source_identifier,omitempty"`
 	Type             string         `json:"type"`
 	UTI              string         `json:"uti"`
 	OriginalFilename string         `json:"original_filename"`

--- a/internal/place/backfill_store.go
+++ b/internal/place/backfill_store.go
@@ -109,11 +109,19 @@ func loadBackfillKeys(ctx context.Context, dbPath string) ([]backfillKey, int, e
 		return nil, 0, err
 	}
 	defer db.Close()
+	assetFilter := ""
+	hasDeletedAt, err := sqliteTableHasColumn(ctx, db, "asset", "deleted_at")
+	if err != nil {
+		return nil, 0, err
+	}
+	if hasDeletedAt {
+		assetFilter = "a.deleted_at is null and "
+	}
 	rows, err := db.QueryContext(ctx, `
 select a.id, a.creation_date, l.latitude, l.longitude, coalesce(l.horizontal_accuracy, 0)
 from location_observation l
 join asset a on a.id = l.asset_id
-where l.latitude != 0 or l.longitude != 0
+where `+assetFilter+`(l.latitude != 0 or l.longitude != 0)
 order by l.latitude, l.longitude, coalesce(l.horizontal_accuracy, 0), a.creation_date, a.id
 `)
 	if err != nil {
@@ -167,6 +175,26 @@ order by l.latitude, l.longitude, coalesce(l.horizontal_accuracy, 0), a.creation
 		keys[i].Index = i
 	}
 	return keys, locatedAssets, nil
+}
+
+func sqliteTableHasColumn(ctx context.Context, db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.QueryContext(ctx, "pragma table_info(\""+table+"\")")
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 func readOnlySQLiteDSN(path string) string {


### PR DESCRIPTION
## Summary

- add explicit asset and resource tombstones with preserved deletion provenance
- make crawls merge-only so omission never deletes, while live records selectively restore present resources
- migrate v1 archives losslessly, preserve legacy derivative lineage, and reject unowned SQLite databases before mutation
- exclude tombstoned assets from search, classification, neighbors, place backfill, and active status counts

## Proof

- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go run golang.org/x/tools/cmd/deadcode@latest ./...`
- built CLI contract proof against a synthetic scratch Photos library: omission remained live, explicit deletion cascaded to derivatives, and selective restoration retained the absent thumbnail tombstone
- AutoReview clean with no accepted or actionable findings
