### PR TITLE
Fix shared-photo source identity and bounded indexing

### DIFF
--- a/internal/archive/classify.go
+++ b/internal/archive/classify.go
@@ -494,7 +494,10 @@ func (input classifyInput) hasUnavailableLocalModelContent(hasImage bool) bool {
 		return true
 	}
 	if !input.hasLocalContent() {
-		return false
+		// PhotoKit may know that an iCloud/shared asset is not local without
+		// marking it as downloadable in the metadata snapshot. Keeping such an
+		// item in metadata_classified makes the bounded runner select it forever.
+		return !input.NeedsDownload
 	}
 	return !input.NeedsDownload
 }

--- a/internal/archive/classify_test.go
+++ b/internal/archive/classify_test.go
@@ -401,6 +401,47 @@ func TestClassifyLocalModelKeepsRemoteImagesRetryable(t *testing.T) {
 	}
 }
 
+func TestClassifyLocalModelFinishesUnavailableImagesWithoutDownloadSignal(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	paths := testPaths(t)
+	libraryPath := filepath.Join(t.TempDir(), "Fixture Photos Library.photoslibrary")
+	if err := mkdirLibrary(libraryPath); err != nil {
+		t.Fatal(err)
+	}
+	provider := fakeProvider{snapshot: photos.LibrarySnapshot{
+		Provider: "fake",
+		Assets: []photos.Asset{{
+			LocalIdentifier: "fixture-unavailable-image",
+			MediaType:       "image",
+			CreationDate:    "2026-05-27T12:00:00Z",
+			Resources: []photos.Resource{{
+				SourceIdentifier: "shared-photo",
+				Type:             "photo",
+				OriginalFilename: "shared.jpeg",
+				Availability:     "unknown",
+			}},
+		}},
+	}}
+	if _, err := Crawl(ctx, paths, CrawlOptions{LibraryPath: libraryPath, Provider: provider, Now: fixedClock("2026-05-28T10:00:00Z")}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := Classify(ctx, paths, ClassifyOptions{All: true, LocalModel: "fixture-vision", Now: fixedClock("2026-05-28T10:15:00Z")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Processed != 1 || first.WaitingForLocalContent != 0 {
+		t.Fatalf("first classify result = %#v", first)
+	}
+	second, err := Classify(ctx, paths, ClassifyOptions{All: true, LocalModel: "fixture-vision", Now: fixedClock("2026-05-28T10:20:00Z")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Processed != 0 {
+		t.Fatalf("unavailable image stayed retryable = %#v", second)
+	}
+}
+
 func TestClassifyLocalModelPrioritizesPendingRowsBeforeWaitingRows(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/archive/migrations.go
+++ b/internal/archive/migrations.go
@@ -37,6 +37,13 @@ func openArchiveStore(ctx context.Context, path string) (*store.Store, error) {
 		_ = db.Close()
 		return nil, errors.New("database is not a photoscrawl archive")
 	}
+	// A current archive must stay read/write without reopening a migration
+	// transaction. Classifiers and crawlers are separate bounded processes;
+	// taking a no-op write lock here made healthy crawls fail while a classifier
+	// was committing a batch.
+	if current == SchemaVersion && isArchive {
+		return db, nil
+	}
 	if _, err := db.DB().ExecContext(ctx, Schema); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("apply archive schema: %w", err)

--- a/internal/archive/timeline.go
+++ b/internal/archive/timeline.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -27,15 +28,23 @@ type TimelineResult struct {
 }
 
 type TimelineObservation struct {
-	AssetID               string   `json:"asset_id"`
-	LocationObservationID string   `json:"location_observation_id,omitempty"`
-	SourceRef             string   `json:"source_ref"`
-	CreatedAt             string   `json:"created_at"`
-	MediaType             string   `json:"media_type"`
-	Latitude              *float64 `json:"lat,omitempty"`
-	Longitude             *float64 `json:"lng,omitempty"`
-	AccuracyMeters        *float64 `json:"accuracy_m,omitempty"`
-	IsPrecise             *bool    `json:"is_precise,omitempty"`
+	AssetID               string          `json:"asset_id"`
+	LocationObservationID string          `json:"location_observation_id,omitempty"`
+	SourceRef             string          `json:"source_ref"`
+	CreatedAt             string          `json:"created_at"`
+	MediaType             string          `json:"media_type"`
+	SourceType            int             `json:"source_type"`
+	Albums                []TimelineAlbum `json:"albums,omitempty"`
+	Latitude              *float64        `json:"lat,omitempty"`
+	Longitude             *float64        `json:"lng,omitempty"`
+	AccuracyMeters        *float64        `json:"accuracy_m,omitempty"`
+	IsPrecise             *bool           `json:"is_precise,omitempty"`
+}
+
+type TimelineAlbum struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Kind  string `json:"kind"`
 }
 
 func Timeline(ctx context.Context, paths Paths, opts TimelineOptions) (TimelineResult, error) {
@@ -65,6 +74,12 @@ func Timeline(ctx context.Context, paths Paths, opts TimelineOptions) (TimelineR
 	}
 	rows, err := db.DB().QueryContext(ctx, `
 select asset.id, location_observation.id, asset.creation_date, asset.media_type,
+       coalesce(cast(json_extract(asset.metadata_json, '$.source_type') as integer), 0),
+       coalesce((
+         select json_group_array(json_object('id', album_id, 'title', album_title, 'kind', album_kind))
+         from album_membership
+         where album_membership.asset_id = asset.id
+       ), '[]'),
        location_observation.latitude, location_observation.longitude,
        location_observation.horizontal_accuracy
 from asset
@@ -88,17 +103,23 @@ order by julianday(asset.creation_date), asset.creation_date, asset.id, location
 	for rows.Next() {
 		var observation TimelineObservation
 		var locationID sql.NullString
+		var albumsJSON string
 		var latitude, longitude, accuracy sql.NullFloat64
 		if err := rows.Scan(
 			&observation.AssetID,
 			&locationID,
 			&observation.CreatedAt,
 			&observation.MediaType,
+			&observation.SourceType,
+			&albumsJSON,
 			&latitude,
 			&longitude,
 			&accuracy,
 		); err != nil {
 			return TimelineResult{}, err
+		}
+		if err := json.Unmarshal([]byte(albumsJSON), &observation.Albums); err != nil {
+			return TimelineResult{}, fmt.Errorf("decode timeline albums: %w", err)
 		}
 		observation.SourceRef = observation.AssetID
 		if locationID.Valid {

--- a/internal/archive/timeline_test.go
+++ b/internal/archive/timeline_test.go
@@ -26,6 +26,10 @@ func TestTimelineReturnsLocatedAssetsInHalfOpenRange(t *testing.T) {
 				TimezoneName:     "Europe/Amsterdam",
 				Width:            4032,
 				Height:           3024,
+				Metadata:         map[string]any{"source_type": 2},
+				Albums: []photos.AlbumMembership{
+					{AlbumID: "shared-trip", AlbumTitle: "Trip", AlbumKind: "album:1:101"},
+				},
 				Location: &photos.Location{
 					Latitude:           52.3676,
 					Longitude:          4.9041,
@@ -71,6 +75,9 @@ func TestTimelineReturnsLocatedAssetsInHalfOpenRange(t *testing.T) {
 	}
 	if observation.CreatedAt != "2026-05-27T10:00:00Z" || observation.MediaType != "image" {
 		t.Fatalf("asset metadata = %#v", observation)
+	}
+	if observation.SourceType != 2 || len(observation.Albums) != 1 || observation.Albums[0].Title != "Trip" {
+		t.Fatalf("source metadata = %#v", observation)
 	}
 	if observation.Latitude == nil || observation.Longitude == nil || observation.AccuracyMeters == nil || *observation.AccuracyMeters != accuracy || observation.IsPrecise == nil || !*observation.IsPrecise {
 		t.Fatalf("location quality = %#v", observation)

--- a/internal/photos/photokit_bridge_darwin.m
+++ b/internal/photos/photokit_bridge_darwin.m
@@ -146,6 +146,7 @@ static id pcJSONSafe(id value) {
 
 static PHAuthorizationStatus pcEnsureAuthorized(void) {
   __block PHAuthorizationStatus status;
+  const int64_t authorizationTimeout = 15 * NSEC_PER_SEC;
   if (@available(macOS 11.0, *)) {
     // macOS Photos exposes asset fetch access through ReadWrite; AddOnly cannot
     // enumerate the library. This bridge still only calls fetch/read APIs.
@@ -156,7 +157,9 @@ static PHAuthorizationStatus pcEnsureAuthorized(void) {
         status = requestedStatus;
         dispatch_semaphore_signal(semaphore);
       }];
-      dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+      if (dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, authorizationTimeout)) != 0) {
+        return PHAuthorizationStatusNotDetermined;
+      }
     }
     return status;
   }
@@ -168,7 +171,9 @@ static PHAuthorizationStatus pcEnsureAuthorized(void) {
       status = requestedStatus;
       dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    if (dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, authorizationTimeout)) != 0) {
+      return PHAuthorizationStatusNotDetermined;
+    }
   }
   return status;
 }


### PR DESCRIPTION
Summary:
- expose PhotoKit source type and album membership in timeline output
- avoid no-op migration write locks for current archives
- terminate unavailable local-content queue entries and bound PhotoKit authorization waits

Tests:
- go test ./...