### PR TITLE
Import Apple Photos search metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ releases. The importer validates every required table and column before it
 writes observations, so an unknown schema fails closed instead of silently
 mislabeling photos.
 
+After upgrading an existing archive to this version, run `photoscrawl init
+--json` once before `status`, `search`, or other read-only commands. This
+applies the required archive migration without recrawling media. If macOS
+reports `operation not permitted` while opening the Photos database, grant Full
+Disk Access to the installed `photoscrawl` executable in **System Settings →
+Privacy & Security → Full Disk Access**, then rerun the import from the logged-in
+macOS session or its background worker.
+
 Crawls merge into the archive. An asset missing from a later enumeration stays
 live; only an explicit provider deletion signal creates a tombstone. Asset
 tombstones retain their reason and also tombstone archived resource rows such as

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ local package media paths for derivatives/renders/originals when they exist, so
 content classification can use local files without changing Photos or iCloud
 state. Every imported asset is queued for `classify`.
 
-`import-apple` copies Apple Photos' live databases into a private temporary
-directory, reads those copies, and removes them when the import finishes. It
+`import-apple` makes verified, consistent copies of Apple Photos' live
+databases in a private temporary directory, reads those copies, and removes
+them when the import finishes. It
 adds Apple's existing named-person records and search index to `photos.sqlite`:
 captions, keywords, detected text, scene labels, activities, venues, dates,
 places, people, camera/source clues, and photo types. Both the current

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ go run ./cmd/photoscrawl metadata --json
 go run ./cmd/photoscrawl init --json
 go run ./cmd/photoscrawl status --json
 go run ./cmd/photoscrawl crawl --library "$HOME/Pictures/Photos Library.photoslibrary" --json
+go run ./cmd/photoscrawl import-apple --library "$HOME/Pictures/Photos Library.photoslibrary" --json
 go run ./cmd/photoscrawl crawl --provider sqlite --library "/path/to/scratch.photoslibrary" --json
 go run ./cmd/photoscrawl classify --limit 100 --json
 go run ./cmd/photoscrawl classify --local-model gemma4:e4b --limit 20 --json
@@ -97,6 +98,20 @@ source. If PhotoKit is unavailable or denied, the POC falls back to a read-only
 local package media paths for derivatives/renders/originals when they exist, so
 content classification can use local files without changing Photos or iCloud
 state. Every imported asset is queued for `classify`.
+
+`import-apple` copies Apple Photos' live databases into a private temporary
+directory, reads those copies, and removes them when the import finishes. It
+adds Apple's existing named-person records and search index to `photos.sqlite`:
+captions, keywords, detected text, scene labels, activities, venues, dates,
+places, people, camera/source clues, and photo types. Both the current
+`psi.sqlite` search index and the newer `leo.sqlite` layout are supported. The
+import is an authoritative refresh of only the Apple-derived observation rows;
+it never writes to the Photos library or uploads the source databases.
+
+Apple's Photos database is a private schema and can change between macOS
+releases. The importer validates every required table and column before it
+writes observations, so an unknown schema fails closed instead of silently
+mislabeling photos.
 
 Crawls merge into the archive. An asset missing from a later enumeration stays
 live; only an explicit provider deletion signal creates a tombstone. Asset
@@ -163,7 +178,11 @@ Today the POC sees useful source facts and optional local multimodal observation
   burst metadata;
 - resource type, UTI, filename, local/remote availability, iCloud download need,
   and resource hash when already local;
-- album membership and raw GPS observations with evidence refs;
+- regular, shared, and smart album membership, album folder paths, and raw GPS
+  observations with evidence refs;
+- Apple Photos captions, keywords, detected text, scene labels, activities,
+  venues, people, camera/source clues, and media categories imported from the
+  local Photos search index;
 - metadata-only observations for media type, local content availability,
   geometry, burst membership, resource UTI/type, and weak
   screenshot/document/receipt candidates from filenames, albums, and metadata;

--- a/cmd/photoscrawl/main.go
+++ b/cmd/photoscrawl/main.go
@@ -134,6 +134,28 @@ func run(ctx context.Context, args []string) error {
 			return err
 		}
 		return output.Write(os.Stdout, format, "crawl", result)
+	case "import-apple":
+		fs := flag.NewFlagSet("import-apple", flag.ContinueOnError)
+		fs.SetOutput(os.Stderr)
+		dbPath := fs.String("db", "", "photos.sqlite path")
+		libraryPath := fs.String("library", "", "Photos Library.photoslibrary path")
+		jsonFlag := fs.Bool("json", false, "write JSON")
+		formatFlag := fs.String("format", "", "output format")
+		if err := fs.Parse(args[1:]); err != nil {
+			return output.UsageError{Err: err}
+		}
+		if *dbPath != "" {
+			paths.Database = *dbPath
+		}
+		format, err := output.Resolve(*formatFlag, *jsonFlag)
+		if err != nil {
+			return err
+		}
+		result, err := archive.ImportApple(ctx, paths, archive.ImportAppleOptions{LibraryPath: *libraryPath})
+		if err != nil {
+			return err
+		}
+		return output.Write(os.Stdout, format, "import_apple", result)
 	case "classify":
 		fs := flag.NewFlagSet("classify", flag.ContinueOnError)
 		fs.SetOutput(os.Stderr)
@@ -420,7 +442,7 @@ func run(ctx context.Context, args []string) error {
 }
 
 func usage() error {
-	return output.UsageError{Err: errors.New("usage: photoscrawl [--version] <version|metadata|init|status|crawl|classify|search|timeline|open|export|neighbors|evidence|place-context|place-card|place-backfill|eval-card>")}
+	return output.UsageError{Err: errors.New("usage: photoscrawl [--version] <version|metadata|init|status|crawl|import-apple|classify|search|timeline|open|export|neighbors|evidence|place-context|place-card|place-backfill|eval-card>")}
 }
 
 func writeVersion(w io.Writer) error {

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -120,6 +120,21 @@ join asset on asset.id = visual_observation.asset_id and asset.deleted_at is nul
 group by observation_type
 order by count(*) desc, observation_type
 `},
+		{"observation.source", "observations from", `
+select source, count(*)
+from (
+  select source, asset_id from visual_observation
+  union all
+  select source, asset_id from text_observation
+  union all
+  select source, asset_id from face_observation
+  union all
+  select source, asset_id from model_observation
+) observations
+join asset on asset.id = observations.asset_id and asset.deleted_at is null
+group by source
+order by count(*) desc, source
+`},
 		{"model_observation.type", "model observation type", `
 select observation_type, count(*)
 from model_observation
@@ -155,10 +170,18 @@ order by count(*) desc, term_type
 		{"asset.with_observation", "assets with local observations", `select count(distinct asset_id) from (
   select asset_id from visual_observation
   union
+  select asset_id from text_observation
+  union
+  select asset_id from face_observation
+  union
   select asset_id from model_observation
 ) where asset_id in (select id from asset where deleted_at is null)`},
 		{"asset.without_observation", "assets without local observations", `select count(*) from asset where deleted_at is null and id not in (
   select asset_id from visual_observation
+  union
+  select asset_id from text_observation
+  union
+  select asset_id from face_observation
   union
   select asset_id from model_observation
 )`},
@@ -207,6 +230,10 @@ func statusSummary(ctx context.Context, db *sql.DB) (string, error) {
 	}
 	if err := db.QueryRowContext(ctx, `select count(distinct asset_id) from (
   select asset_id from visual_observation
+  union
+  select asset_id from text_observation
+  union
+  select asset_id from face_observation
   union
   select asset_id from model_observation
 ) where asset_id in (select id from asset where deleted_at is null)`).Scan(&observations); err != nil {

--- a/internal/archive/classify.go
+++ b/internal/archive/classify.go
@@ -79,6 +79,7 @@ type classifyResource struct {
 type classifyAlbum struct {
 	AlbumTitle string
 	AlbumKind  string
+	FolderPath string
 }
 
 type visualObservation struct {
@@ -306,10 +307,10 @@ order by resource_type, original_filename
 
 func loadClassifyAlbums(ctx context.Context, tx *sql.Tx, assetID string) ([]classifyAlbum, error) {
 	rows, err := tx.QueryContext(ctx, `
-select album_title, album_kind
+select album_title, album_kind, folder_path
 from album_membership
 where asset_id = ?
-order by album_title, album_kind
+order by folder_path, album_title, album_kind
 `, assetID)
 	if err != nil {
 		return nil, fmt.Errorf("load classification albums: %w", err)
@@ -319,7 +320,7 @@ order by album_title, album_kind
 	albums := []classifyAlbum{}
 	for rows.Next() {
 		var album classifyAlbum
-		if err := rows.Scan(&album.AlbumTitle, &album.AlbumKind); err != nil {
+		if err := rows.Scan(&album.AlbumTitle, &album.AlbumKind, &album.FolderPath); err != nil {
 			return nil, err
 		}
 		albums = append(albums, album)
@@ -508,7 +509,7 @@ func (input classifyInput) keywordText() string {
 		parts = append(parts, resource.ResourceType, resource.UTI, resource.OriginalFilename)
 	}
 	for _, album := range input.Albums {
-		parts = append(parts, album.AlbumTitle, album.AlbumKind)
+		parts = append(parts, album.AlbumTitle, album.AlbumKind, album.FolderPath)
 	}
 	return strings.ToLower(strings.Join(parts, " "))
 }

--- a/internal/archive/control.go
+++ b/internal/archive/control.go
@@ -17,7 +17,7 @@ func ControlManifest(paths Paths) control.Manifest {
 		DefaultLogs:     paths.LogDir,
 		DefaultShare:    paths.ShareDir,
 	}
-	manifest.Capabilities = []string{"metadata", "status", "init", "search", "timeline"}
+	manifest.Capabilities = []string{"metadata", "status", "init", "search", "timeline", "face-observations", "apple-search-index"}
 	manifest.Privacy = control.Privacy{
 		ExportsSecrets: false,
 		LocalOnlyScopes: []string{
@@ -25,15 +25,18 @@ func ControlManifest(paths Paths) control.Manifest {
 			"sqlite",
 			"media-metadata",
 			"location-observations",
+			"face-observations",
+			"apple-search-index",
 			"local-model-observations",
 		},
 	}
 	manifest.Commands = map[string]control.Command{
-		"metadata": {Title: "Metadata", Argv: []string{"photoscrawl", "metadata", "--json"}, JSON: true},
-		"status":   {Title: "Status", Argv: []string{"photoscrawl", "status", "--json"}, JSON: true},
-		"init":     {Title: "Initialize archive", Argv: []string{"photoscrawl", "init", "--json"}, JSON: true, Mutates: true},
-		"query":    {Title: "Search", Argv: []string{"photoscrawl", "search", "--json", "--query"}, JSON: true},
-		"timeline": {Title: "Timeline", Argv: []string{"photoscrawl", "timeline", "--json", "--from", "<from>", "--to", "<to>"}, JSON: true},
+		"metadata":     {Title: "Metadata", Argv: []string{"photoscrawl", "metadata", "--json"}, JSON: true},
+		"status":       {Title: "Status", Argv: []string{"photoscrawl", "status", "--json"}, JSON: true},
+		"init":         {Title: "Initialize archive", Argv: []string{"photoscrawl", "init", "--json"}, JSON: true, Mutates: true},
+		"import_apple": {Title: "Import Apple search labels and people", Argv: []string{"photoscrawl", "import-apple", "--json"}, JSON: true, Mutates: true},
+		"query":        {Title: "Search", Argv: []string{"photoscrawl", "search", "--json", "--query"}, JSON: true},
+		"timeline":     {Title: "Timeline", Argv: []string{"photoscrawl", "timeline", "--json", "--from", "<from>", "--to", "<to>"}, JSON: true},
 	}
 	return manifest
 }

--- a/internal/archive/crawl.go
+++ b/internal/archive/crawl.go
@@ -388,7 +388,7 @@ limit 1
 
 func (c *crawlImporter) insertAlbum(ctx context.Context, tx *sql.Tx, assetID string, album photos.AlbumMembership) error {
 	membershipID := stableID("album_membership", assetID, album.AlbumID)
-	if _, err := c.stmts.album.ExecContext(ctx, membershipID, assetID, album.AlbumID, album.AlbumTitle, album.AlbumKind); err != nil {
+	if _, err := c.stmts.album.ExecContext(ctx, membershipID, assetID, album.AlbumID, album.AlbumTitle, album.AlbumKind, album.FolderPath); err != nil {
 		return fmt.Errorf("insert album membership: %w", err)
 	}
 	return c.insertEvidence(ctx, tx, assetID, "album_membership", c.snapshot.Provider, "album:"+album.AlbumID, album)
@@ -444,21 +444,21 @@ order by resource_type, original_filename, id
 		return err
 	}
 	albumRows, err := tx.QueryContext(ctx, `
-select album_title, album_kind
+select album_title, album_kind, folder_path
 from album_membership
 where asset_id = ?
-order by album_title, album_kind, id
+order by folder_path, album_title, album_kind, id
 `, assetID)
 	if err != nil {
 		return fmt.Errorf("load merged album memberships for fts: %w", err)
 	}
 	for albumRows.Next() {
-		var title, kind string
-		if err := albumRows.Scan(&title, &kind); err != nil {
+		var title, kind, folderPath string
+		if err := albumRows.Scan(&title, &kind, &folderPath); err != nil {
 			albumRows.Close()
 			return err
 		}
-		bodyParts = append(bodyParts, title, kind)
+		bodyParts = append(bodyParts, title, kind, folderPath)
 	}
 	if err := albumRows.Close(); err != nil {
 		return err

--- a/internal/archive/crawl_statements.go
+++ b/internal/archive/crawl_statements.go
@@ -92,13 +92,14 @@ on conflict(id) do update set
   deletion_reason = coalesce(nullif(asset_resource.deletion_reason, ''), excluded.deletion_reason)
 `},
 		{&stmts.album, `
-insert into album_membership(id, asset_id, album_id, album_title, album_kind)
-values (?, ?, ?, ?, ?)
+insert into album_membership(id, asset_id, album_id, album_title, album_kind, folder_path)
+values (?, ?, ?, ?, ?, ?)
 on conflict(id) do update set
   asset_id = excluded.asset_id,
   album_id = excluded.album_id,
   album_title = excluded.album_title,
-  album_kind = excluded.album_kind
+  album_kind = excluded.album_kind,
+  folder_path = excluded.folder_path
 `},
 		{&stmts.evidence, `
 insert into evidence_ref(id, asset_id, evidence_kind, source, pointer, value_json)

--- a/internal/archive/crawl_test.go
+++ b/internal/archive/crawl_test.go
@@ -48,6 +48,13 @@ func TestCrawlImportsSnapshotAndTracksDelta(t *testing.T) {
 	if len(search.Results) != 1 {
 		t.Fatalf("search results = %d, want 1", len(search.Results))
 	}
+	folderSearch, err := Search(ctx, paths, SearchOptions{Query: "Studio Archive", Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(folderSearch.Results) != 1 || folderSearch.Results[0].ID != search.Results[0].ID {
+		t.Fatalf("folder search = %#v", folderSearch.Results)
+	}
 
 	opened, err := Open(ctx, paths, search.Results[0].ID)
 	if err != nil {
@@ -55,6 +62,9 @@ func TestCrawlImportsSnapshotAndTracksDelta(t *testing.T) {
 	}
 	if len(opened.Resources) != 1 || len(opened.Albums) != 1 || len(opened.Locations) != 1 || len(opened.Evidence) == 0 {
 		t.Fatalf("open returned resources=%d albums=%d locations=%d evidence=%d", len(opened.Resources), len(opened.Albums), len(opened.Locations), len(opened.Evidence))
+	}
+	if opened.Albums[0]["folder_path"] != "Studio Archive / Media" {
+		t.Fatalf("album folder path = %#v", opened.Albums[0])
 	}
 	evidence, err := Evidence(ctx, paths, search.Results[0].ID)
 	if err != nil {
@@ -542,7 +552,7 @@ func fakeSnapshot(changed, includeSecond bool) photos.LibrarySnapshot {
 					{SourceIdentifier: "fixture-photo", Type: "photo", UTI: "public.heic", OriginalFilename: "Screenshot Beach Fixture.heic", Availability: "remote", NeedsDownload: true},
 				},
 				Albums: []photos.AlbumMembership{
-					{AlbumID: "fixture-album-1", AlbumTitle: "Beach", AlbumKind: "album:1:2"},
+					{AlbumID: "fixture-album-1", AlbumTitle: "Beach", AlbumKind: "album:1:2", FolderPath: "Studio Archive / Media"},
 				},
 			},
 		},

--- a/internal/archive/faces.go
+++ b/internal/archive/faces.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/binary"
 	"errors"
@@ -155,7 +156,7 @@ func ImportFaces(ctx context.Context, paths Paths, opts ImportFacesOptions) (Imp
 	if _, err := os.Stat(liveDBPath); err != nil {
 		return ImportFacesResult{}, fmt.Errorf("find Photos sqlite: %w", err)
 	}
-	snapshotPath, cleanup, err := copyPhotosSQLite(liveDBPath)
+	snapshotPath, cleanup, err := copyPhotosSQLite(ctx, liveDBPath)
 	if err != nil {
 		return ImportFacesResult{}, err
 	}
@@ -244,7 +245,7 @@ func ImportSearchIndex(ctx context.Context, paths Paths, opts ImportSearchIndexO
 	if err != nil {
 		return ImportSearchIndexResult{}, err
 	}
-	snapshotPath, cleanup, err := copySQLite(searchDBPath, "photoscrawl-search-index-")
+	snapshotPath, cleanup, err := copySQLite(ctx, searchDBPath, "photoscrawl-search-index-")
 	if err != nil {
 		return ImportSearchIndexResult{}, err
 	}
@@ -380,34 +381,185 @@ limit 1
 	return filepath.Join(home, "Pictures", "Photos Library.photoslibrary"), nil
 }
 
-func copyPhotosSQLite(liveDBPath string) (string, func(), error) {
-	return copySQLite(liveDBPath, "photoscrawl-faces-")
+func copyPhotosSQLite(ctx context.Context, liveDBPath string) (string, func(), error) {
+	return copySQLite(ctx, liveDBPath, "photoscrawl-faces-")
 }
 
-func copySQLite(liveDBPath string, tempPrefix string) (string, func(), error) {
+type sqliteFileState struct {
+	exists      bool
+	size        int64
+	modifiedNS  int64
+	contentHash [sha256.Size]byte
+}
+
+func copySQLite(ctx context.Context, liveDBPath string, tempPrefix string) (string, func(), error) {
 	dir, err := os.MkdirTemp("", tempPrefix)
 	if err != nil {
 		return "", func() {}, err
 	}
 	cleanup := func() { _ = os.RemoveAll(dir) }
 	dest := filepath.Join(dir, filepath.Base(liveDBPath))
-	if err := copyFile(liveDBPath, dest, 0o600); err != nil {
-		cleanup()
-		return "", func() {}, err
-	}
-	for _, suffix := range []string{"-wal", "-shm"} {
-		source := liveDBPath + suffix
-		if _, err := os.Stat(source); err == nil {
-			if err := copyFile(source, dest+suffix, 0o600); err != nil {
-				cleanup()
-				return "", func() {}, err
-			}
-		} else if !errors.Is(err, os.ErrNotExist) {
+	for attempt := 1; attempt <= 5; attempt++ {
+		if err := ctx.Err(); err != nil {
 			cleanup()
 			return "", func() {}, err
 		}
+		_ = os.Remove(dest)
+		_ = os.Remove(dest + "-wal")
+		before, err := statSQLiteFiles(liveDBPath)
+		if err != nil {
+			cleanup()
+			return "", func() {}, err
+		}
+		copied, err := copySQLiteFiles(liveDBPath, dest, before)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			cleanup()
+			return "", func() {}, err
+		}
+		after, err := hashSQLiteFiles(liveDBPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			cleanup()
+			return "", func() {}, err
+		}
+		if sqliteFilesStable(before, copied, after) {
+			if err := verifySQLiteSnapshot(ctx, dest); err == nil {
+				return dest, cleanup, nil
+			}
+		}
 	}
-	return dest, cleanup, nil
+	cleanup()
+	return "", func() {}, fmt.Errorf("create consistent SQLite snapshot: source kept changing during 5 attempts")
+}
+
+func statSQLiteFiles(dbPath string) (map[string]sqliteFileState, error) {
+	out := map[string]sqliteFileState{}
+	for _, suffix := range []string{"", "-wal"} {
+		path := dbPath + suffix
+		info, err := os.Stat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			out[suffix] = sqliteFileState{}
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("inspect SQLite source %s: %w", path, err)
+		}
+		out[suffix] = sqliteFileState{exists: true, size: info.Size(), modifiedNS: info.ModTime().UnixNano()}
+	}
+	if !out[""].exists {
+		return nil, fmt.Errorf("SQLite source does not exist: %s", dbPath)
+	}
+	return out, nil
+}
+
+func copySQLiteFiles(sourceDB, destDB string, before map[string]sqliteFileState) (map[string]sqliteFileState, error) {
+	out := map[string]sqliteFileState{}
+	for _, suffix := range []string{"", "-wal"} {
+		if !before[suffix].exists {
+			out[suffix] = sqliteFileState{}
+			continue
+		}
+		digest, err := copyFileWithHash(sourceDB+suffix, destDB+suffix, 0o600)
+		if err != nil {
+			return nil, err
+		}
+		state := before[suffix]
+		state.contentHash = digest
+		out[suffix] = state
+	}
+	return out, nil
+}
+
+func hashSQLiteFiles(dbPath string) (map[string]sqliteFileState, error) {
+	states, err := statSQLiteFiles(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	for _, suffix := range []string{"", "-wal"} {
+		state := states[suffix]
+		if !state.exists {
+			continue
+		}
+		file, err := os.Open(dbPath + suffix)
+		if err != nil {
+			return nil, fmt.Errorf("open SQLite source %s: %w", dbPath+suffix, err)
+		}
+		digest := sha256.New()
+		_, copyErr := io.Copy(digest, file)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return nil, fmt.Errorf("hash SQLite source %s: %w", dbPath+suffix, copyErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close SQLite source %s: %w", dbPath+suffix, closeErr)
+		}
+		copy(state.contentHash[:], digest.Sum(nil))
+		states[suffix] = state
+	}
+	return states, nil
+}
+
+func sqliteFilesStable(before, copied, after map[string]sqliteFileState) bool {
+	for _, suffix := range []string{"", "-wal"} {
+		if before[suffix].exists != after[suffix].exists || copied[suffix].exists != after[suffix].exists {
+			return false
+		}
+		if !after[suffix].exists {
+			continue
+		}
+		if before[suffix].size != after[suffix].size || before[suffix].modifiedNS != after[suffix].modifiedNS {
+			return false
+		}
+		if copied[suffix].contentHash != after[suffix].contentHash {
+			return false
+		}
+	}
+	return true
+}
+
+func verifySQLiteSnapshot(ctx context.Context, path string) error {
+	db, err := store.OpenReadOnly(ctx, path)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	var result string
+	if err := db.DB().QueryRowContext(ctx, `pragma quick_check`).Scan(&result); err != nil {
+		return err
+	}
+	if result != "ok" {
+		return fmt.Errorf("SQLite snapshot quick check: %s", result)
+	}
+	return nil
+}
+
+func copyFileWithHash(source, dest string, mode os.FileMode) ([sha256.Size]byte, error) {
+	var outHash [sha256.Size]byte
+	in, err := os.Open(source)
+	if err != nil {
+		return outHash, fmt.Errorf("open %s: %w", source, err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		return outHash, fmt.Errorf("create %s: %w", dest, err)
+	}
+	digest := sha256.New()
+	_, copyErr := io.Copy(io.MultiWriter(out, digest), in)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return outHash, fmt.Errorf("copy %s: %w", source, copyErr)
+	}
+	if closeErr != nil {
+		return outHash, fmt.Errorf("close %s: %w", dest, closeErr)
+	}
+	copy(outHash[:], digest.Sum(nil))
+	return outHash, nil
 }
 
 func resolveAppleSearchDB(libraryPath string) (string, string, string, error) {
@@ -430,27 +582,6 @@ func resolveAppleSearchDB(libraryPath string) (string, string, string, error) {
 		}
 	}
 	return "", "", "", fmt.Errorf("find Apple Photos search index: neither %s nor %s exists with content", filepath.Join(searchDir, "psi.sqlite"), filepath.Join(searchDir, "leo.sqlite"))
-}
-
-func copyFile(source, dest string, mode os.FileMode) error {
-	in, err := os.Open(source)
-	if err != nil {
-		return fmt.Errorf("open %s: %w", source, err)
-	}
-	defer in.Close()
-	out, err := os.OpenFile(dest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
-	if err != nil {
-		return fmt.Errorf("create %s: %w", dest, err)
-	}
-	_, copyErr := io.Copy(out, in)
-	closeErr := out.Close()
-	if copyErr != nil {
-		return fmt.Errorf("copy %s: %w", source, copyErr)
-	}
-	if closeErr != nil {
-		return fmt.Errorf("close %s: %w", dest, closeErr)
-	}
-	return nil
 }
 
 func validatePhotosFacesSchema(ctx context.Context, db *sql.DB) (map[string]string, error) {
@@ -655,7 +786,7 @@ func loadPhotosPeopleByUUID(ctx context.Context, libraryPath string) (map[string
 	if _, err := os.Stat(liveDBPath); err != nil {
 		return nil, fmt.Errorf("find Photos sqlite for people lookup: %w", err)
 	}
-	snapshotPath, cleanup, err := copyPhotosSQLite(liveDBPath)
+	snapshotPath, cleanup, err := copyPhotosSQLite(ctx, liveDBPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/archive/faces.go
+++ b/internal/archive/faces.go
@@ -113,24 +113,71 @@ type appleSearchCategory struct {
 	SemanticKind string
 }
 
+type facesImportInput struct {
+	libraryPath  string
+	schema       map[string]string
+	rows         []photosFaceRow
+	namedPersons int
+	unnamedFaces int
+	peopleByUUID map[string]photosPerson
+}
+
+type searchImportInput struct {
+	variant string
+	relPath string
+	schema  map[string]string
+	rows    []appleSearchRow
+}
+
 func ImportApple(ctx context.Context, paths Paths, opts ImportAppleOptions) (ImportAppleResult, error) {
 	importedAt := time.Now().UTC()
-	faces, err := ImportFaces(ctx, paths, ImportFacesOptions{LibraryPath: opts.LibraryPath})
+	libraryPath, err := resolveFacesLibraryPath(ctx, paths, opts.LibraryPath)
 	if err != nil {
 		return ImportAppleResult{}, err
 	}
-	searchIndex, err := ImportSearchIndex(ctx, paths, ImportSearchIndexOptions{LibraryPath: opts.LibraryPath})
+	facesInput, err := preflightFacesImport(ctx, libraryPath)
 	if err != nil {
 		return ImportAppleResult{}, err
 	}
-	totalTouched := faces.AssetsTouched + searchIndex.AssetsTouched
+	searchInput, err := preflightSearchImport(ctx, libraryPath)
+	if err != nil {
+		return ImportAppleResult{}, err
+	}
+	archiveDB, err := openArchiveStore(ctx, paths.Database)
+	if err != nil {
+		return ImportAppleResult{}, err
+	}
+	defer archiveDB.Close()
+	assetByUUID, err := archiveAssetMap(ctx, archiveDB.DB())
+	if err != nil {
+		return ImportAppleResult{}, err
+	}
+	tx, err := archiveDB.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return ImportAppleResult{}, err
+	}
+	defer tx.Rollback()
+	faces, faceAssets, err := writeFacesImport(ctx, tx, paths, facesInput, assetByUUID, importedAt)
+	if err != nil {
+		return ImportAppleResult{}, err
+	}
+	searchIndex, searchAssets, err := writeSearchImport(ctx, tx, searchInput, assetByUUID, facesInput.peopleByUUID, importedAt)
+	if err != nil {
+		return ImportAppleResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ImportAppleResult{}, err
+	}
+	for assetID := range searchAssets {
+		faceAssets[assetID] = true
+	}
 	return ImportAppleResult{
 		Database:           paths.Database,
-		LibraryPath:        faces.LibraryPath,
+		LibraryPath:        libraryPath,
 		Faces:              faces,
 		SearchIndex:        searchIndex,
-		TotalAssetsTouched: totalTouched,
-		SyncStrategy:       "authoritative_replace_by_source",
+		TotalAssetsTouched: len(faceAssets),
+		SyncStrategy:       "atomic_authoritative_replace_by_source",
 		ImportedAt:         importedAt.Format(time.RFC3339Nano),
 		OsxphotosReferences: []string{
 			"osxphotos/photosdb/_photosdb_process_searchinfo.py:_process_searchinfo",
@@ -152,84 +199,33 @@ func ImportFaces(ctx context.Context, paths Paths, opts ImportFacesOptions) (Imp
 	if err != nil {
 		return ImportFacesResult{}, err
 	}
-	liveDBPath := filepath.Join(libraryPath, "database", "Photos.sqlite")
-	if _, err := os.Stat(liveDBPath); err != nil {
-		return ImportFacesResult{}, fmt.Errorf("find Photos sqlite: %w", err)
-	}
-	snapshotPath, cleanup, err := copyPhotosSQLite(ctx, liveDBPath)
+	input, err := preflightFacesImport(ctx, libraryPath)
 	if err != nil {
 		return ImportFacesResult{}, err
 	}
-	defer cleanup()
-
 	archiveDB, err := openArchiveStore(ctx, paths.Database)
 	if err != nil {
 		return ImportFacesResult{}, err
 	}
 	defer archiveDB.Close()
 
-	photosDB, err := store.OpenReadOnly(ctx, snapshotPath)
-	if err != nil {
-		return ImportFacesResult{}, fmt.Errorf("open copied Photos sqlite: %w", err)
-	}
-	defer photosDB.Close()
-
-	schema, err := validatePhotosFacesSchema(ctx, photosDB.DB())
-	if err != nil {
-		return ImportFacesResult{}, err
-	}
 	assetByUUID, err := archiveAssetMap(ctx, archiveDB.DB())
 	if err != nil {
 		return ImportFacesResult{}, err
 	}
-	faceRows, namedPersons, unnamedFaces, err := loadPhotosFaceRows(ctx, photosDB.DB())
-	if err != nil {
-		return ImportFacesResult{}, err
-	}
-
 	tx, err := archiveDB.DB().BeginTx(ctx, nil)
 	if err != nil {
 		return ImportFacesResult{}, err
 	}
 	defer tx.Rollback()
-	if err := clearImportedFaces(ctx, tx); err != nil {
+	result, _, err := writeFacesImport(ctx, tx, paths, input, assetByUUID, time.Now().UTC())
+	if err != nil {
 		return ImportFacesResult{}, err
-	}
-
-	inserted := 0
-	unresolved := 0
-	touched := map[string]bool{}
-	importedAt := time.Now().UTC()
-	for _, face := range faceRows {
-		assetID, ok := assetByUUID[face.assetUUID]
-		if !ok {
-			unresolved++
-			continue
-		}
-		if err := insertImportedFace(ctx, tx, assetID, face, importedAt); err != nil {
-			return ImportFacesResult{}, err
-		}
-		inserted++
-		touched[assetID] = true
 	}
 	if err := tx.Commit(); err != nil {
 		return ImportFacesResult{}, err
 	}
-
-	return ImportFacesResult{
-		Database:                 paths.Database,
-		LibraryPath:              libraryPath,
-		Source:                   photosLibraryDBFaceSource,
-		PhotosDatabase:           "database/Photos.sqlite",
-		Schema:                   schema,
-		NamedPersonsFound:        namedPersons,
-		NamedFaceRowsFound:       len(faceRows),
-		ResolvedFaceRows:         inserted,
-		UnresolvedFaceRows:       unresolved,
-		FaceObservationsInserted: inserted,
-		AssetsTouched:            len(touched),
-		UnnamedFacesSkipped:      unnamedFaces,
-	}, nil
+	return result, nil
 }
 
 type ImportSearchIndexOptions struct {
@@ -241,47 +237,16 @@ func ImportSearchIndex(ctx context.Context, paths Paths, opts ImportSearchIndexO
 	if err != nil {
 		return ImportSearchIndexResult{}, err
 	}
-	searchDBPath, variant, relPath, err := resolveAppleSearchDB(libraryPath)
+	input, err := preflightSearchImport(ctx, libraryPath)
 	if err != nil {
 		return ImportSearchIndexResult{}, err
 	}
-	snapshotPath, cleanup, err := copySQLite(ctx, searchDBPath, "photoscrawl-search-index-")
-	if err != nil {
-		return ImportSearchIndexResult{}, err
-	}
-	defer cleanup()
-
 	archiveDB, err := openArchiveStore(ctx, paths.Database)
 	if err != nil {
 		return ImportSearchIndexResult{}, err
 	}
 	defer archiveDB.Close()
 
-	searchDB, err := store.OpenReadOnly(ctx, snapshotPath)
-	if err != nil {
-		return ImportSearchIndexResult{}, fmt.Errorf("open copied Apple search index: %w", err)
-	}
-	defer searchDB.Close()
-
-	var schema map[string]string
-	var searchRows []appleSearchRow
-	switch variant {
-	case "psi":
-		schema, err = validatePSISearchSchema(ctx, searchDB.DB())
-		if err == nil {
-			searchRows, err = loadPSISearchRows(ctx, searchDB.DB())
-		}
-	case "leo":
-		schema, err = validateLeoSearchSchema(ctx, searchDB.DB())
-		if err == nil {
-			searchRows, err = loadLeoSearchRows(ctx, searchDB.DB())
-		}
-	default:
-		err = fmt.Errorf("unsupported Apple search index variant: %s", variant)
-	}
-	if err != nil {
-		return ImportSearchIndexResult{}, err
-	}
 	assetByUUID, err := archiveAssetMap(ctx, archiveDB.DB())
 	if err != nil {
 		return ImportSearchIndexResult{}, err
@@ -295,32 +260,147 @@ func ImportSearchIndex(ctx context.Context, paths Paths, opts ImportSearchIndexO
 		return ImportSearchIndexResult{}, err
 	}
 	defer tx.Rollback()
-	if err := clearImportedSearchIndex(ctx, tx); err != nil {
+	result, _, err := writeSearchImport(ctx, tx, input, assetByUUID, peopleByUUID, time.Now().UTC())
+	if err != nil {
 		return ImportSearchIndexResult{}, err
 	}
+	if err := tx.Commit(); err != nil {
+		return ImportSearchIndexResult{}, err
+	}
+	return result, nil
+}
 
+func preflightFacesImport(ctx context.Context, libraryPath string) (facesImportInput, error) {
+	liveDBPath := filepath.Join(libraryPath, "database", "Photos.sqlite")
+	if _, err := os.Stat(liveDBPath); err != nil {
+		return facesImportInput{}, fmt.Errorf("find Photos sqlite: %w", err)
+	}
+	snapshotPath, cleanup, err := copyPhotosSQLite(ctx, liveDBPath)
+	if err != nil {
+		return facesImportInput{}, err
+	}
+	defer cleanup()
+	photosDB, err := store.OpenReadOnly(ctx, snapshotPath)
+	if err != nil {
+		return facesImportInput{}, fmt.Errorf("open copied Photos sqlite: %w", err)
+	}
+	defer photosDB.Close()
+	schema, err := validatePhotosFacesSchema(ctx, photosDB.DB())
+	if err != nil {
+		return facesImportInput{}, err
+	}
+	faceRows, namedPersons, unnamedFaces, err := loadPhotosFaceRows(ctx, photosDB.DB())
+	if err != nil {
+		return facesImportInput{}, err
+	}
+	peopleByUUID, err := loadPhotosPeopleByUUIDFromDB(ctx, photosDB.DB())
+	if err != nil {
+		return facesImportInput{}, err
+	}
+	return facesImportInput{
+		libraryPath:  libraryPath,
+		schema:       schema,
+		rows:         faceRows,
+		namedPersons: namedPersons,
+		unnamedFaces: unnamedFaces,
+		peopleByUUID: peopleByUUID,
+	}, nil
+}
+
+func preflightSearchImport(ctx context.Context, libraryPath string) (searchImportInput, error) {
+	searchDBPath, variant, relPath, err := resolveAppleSearchDB(libraryPath)
+	if err != nil {
+		return searchImportInput{}, err
+	}
+	snapshotPath, cleanup, err := copySQLite(ctx, searchDBPath, "photoscrawl-search-index-")
+	if err != nil {
+		return searchImportInput{}, err
+	}
+	defer cleanup()
+	searchDB, err := store.OpenReadOnly(ctx, snapshotPath)
+	if err != nil {
+		return searchImportInput{}, fmt.Errorf("open copied Apple search index: %w", err)
+	}
+	defer searchDB.Close()
+	input := searchImportInput{variant: variant, relPath: relPath}
+	switch variant {
+	case "psi":
+		input.schema, err = validatePSISearchSchema(ctx, searchDB.DB())
+		if err == nil {
+			input.rows, err = loadPSISearchRows(ctx, searchDB.DB())
+		}
+	case "leo":
+		input.schema, err = validateLeoSearchSchema(ctx, searchDB.DB())
+		if err == nil {
+			input.rows, err = loadLeoSearchRows(ctx, searchDB.DB())
+		}
+	default:
+		err = fmt.Errorf("unsupported Apple search index variant: %s", variant)
+	}
+	if err != nil {
+		return searchImportInput{}, err
+	}
+	return input, nil
+}
+
+func writeFacesImport(ctx context.Context, tx *sql.Tx, paths Paths, input facesImportInput, assetByUUID map[string]string, importedAt time.Time) (ImportFacesResult, map[string]bool, error) {
+	if err := clearImportedFaces(ctx, tx); err != nil {
+		return ImportFacesResult{}, nil, err
+	}
+	inserted := 0
+	unresolved := 0
+	touched := map[string]bool{}
+	for _, face := range input.rows {
+		assetID, ok := assetByUUID[face.assetUUID]
+		if !ok {
+			unresolved++
+			continue
+		}
+		if err := insertImportedFace(ctx, tx, assetID, face, importedAt); err != nil {
+			return ImportFacesResult{}, nil, err
+		}
+		inserted++
+		touched[assetID] = true
+	}
+	return ImportFacesResult{
+		Database:                 paths.Database,
+		LibraryPath:              input.libraryPath,
+		Source:                   photosLibraryDBFaceSource,
+		PhotosDatabase:           "database/Photos.sqlite",
+		Schema:                   input.schema,
+		NamedPersonsFound:        input.namedPersons,
+		NamedFaceRowsFound:       len(input.rows),
+		ResolvedFaceRows:         inserted,
+		UnresolvedFaceRows:       unresolved,
+		FaceObservationsInserted: inserted,
+		AssetsTouched:            len(touched),
+		UnnamedFacesSkipped:      input.unnamedFaces,
+	}, touched, nil
+}
+
+func writeSearchImport(ctx context.Context, tx *sql.Tx, input searchImportInput, assetByUUID map[string]string, peopleByUUID map[string]photosPerson, importedAt time.Time) (ImportSearchIndexResult, map[string]bool, error) {
+	if err := clearImportedSearchIndex(ctx, tx); err != nil {
+		return ImportSearchIndexResult{}, nil, err
+	}
 	result := ImportSearchIndexResult{
 		Source:         photosSearchIndexSource,
-		Variant:        variant,
-		SearchDatabase: relPath,
-		Schema:         schema,
+		Variant:        input.variant,
+		SearchDatabase: input.relPath,
+		Schema:         input.schema,
 		CategoriesSeen: map[string]int{},
 	}
 	touched := map[string]bool{}
 	unknownCategories := map[int]bool{}
-	importedAt := time.Now().UTC()
-	for _, row := range searchRows {
+	for _, row := range input.rows {
 		result.GroupsRead++
 		category := appleSearchCategoryForID(row.category)
-		categoryKey := fmt.Sprint(row.category)
-		result.CategoriesSeen[categoryKey]++
+		result.CategoriesSeen[fmt.Sprint(row.category)]++
 		if category.Name == "UNKNOWN" {
 			result.UnknownCategoryRows++
 			unknownCategories[row.category] = true
 		} else {
 			result.KnownCategoryRows++
 		}
-
 		assetID, ok := assetByUUID[row.assetUUID]
 		if !ok {
 			result.GroupsUnresolved++
@@ -335,7 +415,7 @@ func ImportSearchIndex(ctx context.Context, paths Paths, opts ImportSearchIndexO
 			}
 		}
 		if err := insertImportedSearchObservation(ctx, tx, assetID, row, category, person, hasPerson, importedAt); err != nil {
-			return ImportSearchIndexResult{}, err
+			return ImportSearchIndexResult{}, nil, err
 		}
 		result.GroupsResolved++
 		result.VisualObservationsInserted++
@@ -344,15 +424,12 @@ func ImportSearchIndex(ctx context.Context, paths Paths, opts ImportSearchIndexO
 		}
 		touched[assetID] = true
 	}
-	if err := tx.Commit(); err != nil {
-		return ImportSearchIndexResult{}, err
-	}
 	result.AssetsTouched = len(touched)
 	for id := range unknownCategories {
 		result.UnknownCategories = append(result.UnknownCategories, id)
 	}
 	sort.Ints(result.UnknownCategories)
-	return result, nil
+	return result, touched, nil
 }
 
 func resolveFacesLibraryPath(ctx context.Context, paths Paths, requested string) (string, error) {
@@ -799,7 +876,11 @@ func loadPhotosPeopleByUUID(ctx context.Context, libraryPath string) (map[string
 	if _, err := validatePhotosFacesSchema(ctx, photosDB.DB()); err != nil {
 		return nil, err
 	}
-	rows, err := photosDB.DB().QueryContext(ctx, `
+	return loadPhotosPeopleByUUIDFromDB(ctx, photosDB.DB())
+}
+
+func loadPhotosPeopleByUUIDFromDB(ctx context.Context, db *sql.DB) (map[string]photosPerson, error) {
+	rows, err := db.QueryContext(ctx, `
 select coalesce(ZPERSONUUID, ''), coalesce(ZDISPLAYNAME, ''), coalesce(ZFULLNAME, '')
 from ZPERSON
 where coalesce(ZPERSONUUID, '') <> ''

--- a/internal/archive/faces.go
+++ b/internal/archive/faces.go
@@ -1,0 +1,1151 @@
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/openclaw/crawlkit/store"
+)
+
+const photosLibraryDBFaceSource = "photos_library_db"
+const photosSearchIndexSource = "photos_search_index"
+const photosSearchIndexModelID = "apple.photos.search-index"
+
+type ImportAppleOptions struct {
+	LibraryPath string
+}
+
+type ImportAppleResult struct {
+	Database            string                  `json:"database"`
+	LibraryPath         string                  `json:"library_path"`
+	Faces               ImportFacesResult       `json:"faces"`
+	SearchIndex         ImportSearchIndexResult `json:"search_index"`
+	TotalAssetsTouched  int                     `json:"total_assets_touched"`
+	SyncStrategy        string                  `json:"sync_strategy"`
+	ImportedAt          string                  `json:"imported_at"`
+	OsxphotosReferences []string                `json:"osxphotos_references"`
+}
+
+type ImportFacesResult struct {
+	Database                 string            `json:"database"`
+	LibraryPath              string            `json:"library_path"`
+	Source                   string            `json:"source"`
+	PhotosDatabase           string            `json:"photos_database"`
+	Schema                   map[string]string `json:"schema"`
+	NamedPersonsFound        int               `json:"named_persons_found"`
+	NamedFaceRowsFound       int               `json:"named_face_rows_found"`
+	ResolvedFaceRows         int               `json:"resolved_face_rows"`
+	UnresolvedFaceRows       int               `json:"unresolved_face_rows"`
+	FaceObservationsInserted int               `json:"face_observations_inserted"`
+	AssetsTouched            int               `json:"assets_touched"`
+	UnnamedFacesSkipped      int               `json:"unnamed_faces_skipped"`
+}
+
+type ImportSearchIndexResult struct {
+	Source                            string            `json:"source"`
+	Variant                           string            `json:"variant"`
+	SearchDatabase                    string            `json:"search_database"`
+	Schema                            map[string]string `json:"schema"`
+	GroupsRead                        int               `json:"groups_read"`
+	GroupsResolved                    int               `json:"groups_resolved"`
+	GroupsUnresolved                  int               `json:"groups_unresolved"`
+	KnownCategoryRows                 int               `json:"known_category_rows"`
+	UnknownCategoryRows               int               `json:"unknown_category_rows"`
+	CategoriesSeen                    map[string]int    `json:"categories_seen"`
+	UnknownCategories                 []int             `json:"unknown_categories"`
+	VisualObservationsInserted        int               `json:"visual_observations_inserted"`
+	PersonFaceObservationsInserted    int               `json:"person_face_observations_inserted"`
+	AssetsTouched                     int               `json:"assets_touched"`
+	PersonLookupIdentifiersResolved   int               `json:"person_lookup_identifiers_resolved"`
+	PersonLookupIdentifiersUnresolved int               `json:"person_lookup_identifiers_unresolved"`
+}
+
+type photosFaceRow struct {
+	facePK       int64
+	faceUUID     string
+	assetUUID    string
+	personLabel  string
+	personUUID   string
+	nameSource   int64
+	cloudSource  int64
+	quality      sql.NullFloat64
+	centerX      sql.NullFloat64
+	centerY      sql.NullFloat64
+	size         sql.NullFloat64
+	sourceWidth  sql.NullInt64
+	sourceHeight sql.NullInt64
+}
+
+type photosPerson struct {
+	uuid        string
+	displayName string
+	fullName    string
+}
+
+type appleSearchRow struct {
+	searchVariant    string
+	gaRowID          int64
+	uuid0            int64
+	uuid1            int64
+	assetUUID        string
+	groupID          int64
+	category         int
+	owningGroupID    sql.NullInt64
+	contentString    string
+	normalizedString string
+	lookupIdentifier string
+	score            sql.NullFloat64
+}
+
+type appleSearchCategory struct {
+	ID           int
+	Name         string
+	SemanticKind string
+}
+
+func ImportApple(ctx context.Context, paths Paths, opts ImportAppleOptions) (ImportAppleResult, error) {
+	importedAt := time.Now().UTC()
+	faces, err := ImportFaces(ctx, paths, ImportFacesOptions{LibraryPath: opts.LibraryPath})
+	if err != nil {
+		return ImportAppleResult{}, err
+	}
+	searchIndex, err := ImportSearchIndex(ctx, paths, ImportSearchIndexOptions{LibraryPath: opts.LibraryPath})
+	if err != nil {
+		return ImportAppleResult{}, err
+	}
+	totalTouched := faces.AssetsTouched + searchIndex.AssetsTouched
+	return ImportAppleResult{
+		Database:           paths.Database,
+		LibraryPath:        faces.LibraryPath,
+		Faces:              faces,
+		SearchIndex:        searchIndex,
+		TotalAssetsTouched: totalTouched,
+		SyncStrategy:       "authoritative_replace_by_source",
+		ImportedAt:         importedAt.Format(time.RFC3339Nano),
+		OsxphotosReferences: []string{
+			"osxphotos/photosdb/_photosdb_process_searchinfo.py:_process_searchinfo",
+			"osxphotos/photosdb/_photosdb_process_searchinfo.py:_process_psi_searchinfo",
+			"osxphotos/photosdb/_photosdb_process_searchinfo.py:_process_leo_searchinfo",
+			"osxphotos/photosdb/_photosdb_process_searchinfo.py:decode_leo_lexeme_ids",
+			"osxphotos/photosdb/_photosdb_process_searchinfo.py:ints_to_uuid",
+			"osxphotos/_constants.py:SearchCategory_Photos8",
+		},
+	}, nil
+}
+
+type ImportFacesOptions struct {
+	LibraryPath string
+}
+
+func ImportFaces(ctx context.Context, paths Paths, opts ImportFacesOptions) (ImportFacesResult, error) {
+	libraryPath, err := resolveFacesLibraryPath(ctx, paths, opts.LibraryPath)
+	if err != nil {
+		return ImportFacesResult{}, err
+	}
+	liveDBPath := filepath.Join(libraryPath, "database", "Photos.sqlite")
+	if _, err := os.Stat(liveDBPath); err != nil {
+		return ImportFacesResult{}, fmt.Errorf("find Photos sqlite: %w", err)
+	}
+	snapshotPath, cleanup, err := copyPhotosSQLite(liveDBPath)
+	if err != nil {
+		return ImportFacesResult{}, err
+	}
+	defer cleanup()
+
+	archiveDB, err := openArchiveStore(ctx, paths.Database)
+	if err != nil {
+		return ImportFacesResult{}, err
+	}
+	defer archiveDB.Close()
+
+	photosDB, err := store.OpenReadOnly(ctx, snapshotPath)
+	if err != nil {
+		return ImportFacesResult{}, fmt.Errorf("open copied Photos sqlite: %w", err)
+	}
+	defer photosDB.Close()
+
+	schema, err := validatePhotosFacesSchema(ctx, photosDB.DB())
+	if err != nil {
+		return ImportFacesResult{}, err
+	}
+	assetByUUID, err := archiveAssetMap(ctx, archiveDB.DB())
+	if err != nil {
+		return ImportFacesResult{}, err
+	}
+	faceRows, namedPersons, unnamedFaces, err := loadPhotosFaceRows(ctx, photosDB.DB())
+	if err != nil {
+		return ImportFacesResult{}, err
+	}
+
+	tx, err := archiveDB.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return ImportFacesResult{}, err
+	}
+	defer tx.Rollback()
+	if err := clearImportedFaces(ctx, tx); err != nil {
+		return ImportFacesResult{}, err
+	}
+
+	inserted := 0
+	unresolved := 0
+	touched := map[string]bool{}
+	importedAt := time.Now().UTC()
+	for _, face := range faceRows {
+		assetID, ok := assetByUUID[face.assetUUID]
+		if !ok {
+			unresolved++
+			continue
+		}
+		if err := insertImportedFace(ctx, tx, assetID, face, importedAt); err != nil {
+			return ImportFacesResult{}, err
+		}
+		inserted++
+		touched[assetID] = true
+	}
+	if err := tx.Commit(); err != nil {
+		return ImportFacesResult{}, err
+	}
+
+	return ImportFacesResult{
+		Database:                 paths.Database,
+		LibraryPath:              libraryPath,
+		Source:                   photosLibraryDBFaceSource,
+		PhotosDatabase:           "database/Photos.sqlite",
+		Schema:                   schema,
+		NamedPersonsFound:        namedPersons,
+		NamedFaceRowsFound:       len(faceRows),
+		ResolvedFaceRows:         inserted,
+		UnresolvedFaceRows:       unresolved,
+		FaceObservationsInserted: inserted,
+		AssetsTouched:            len(touched),
+		UnnamedFacesSkipped:      unnamedFaces,
+	}, nil
+}
+
+type ImportSearchIndexOptions struct {
+	LibraryPath string
+}
+
+func ImportSearchIndex(ctx context.Context, paths Paths, opts ImportSearchIndexOptions) (ImportSearchIndexResult, error) {
+	libraryPath, err := resolveFacesLibraryPath(ctx, paths, opts.LibraryPath)
+	if err != nil {
+		return ImportSearchIndexResult{}, err
+	}
+	searchDBPath, variant, relPath, err := resolveAppleSearchDB(libraryPath)
+	if err != nil {
+		return ImportSearchIndexResult{}, err
+	}
+	snapshotPath, cleanup, err := copySQLite(searchDBPath, "photoscrawl-search-index-")
+	if err != nil {
+		return ImportSearchIndexResult{}, err
+	}
+	defer cleanup()
+
+	archiveDB, err := openArchiveStore(ctx, paths.Database)
+	if err != nil {
+		return ImportSearchIndexResult{}, err
+	}
+	defer archiveDB.Close()
+
+	searchDB, err := store.OpenReadOnly(ctx, snapshotPath)
+	if err != nil {
+		return ImportSearchIndexResult{}, fmt.Errorf("open copied Apple search index: %w", err)
+	}
+	defer searchDB.Close()
+
+	var schema map[string]string
+	var searchRows []appleSearchRow
+	switch variant {
+	case "psi":
+		schema, err = validatePSISearchSchema(ctx, searchDB.DB())
+		if err == nil {
+			searchRows, err = loadPSISearchRows(ctx, searchDB.DB())
+		}
+	case "leo":
+		schema, err = validateLeoSearchSchema(ctx, searchDB.DB())
+		if err == nil {
+			searchRows, err = loadLeoSearchRows(ctx, searchDB.DB())
+		}
+	default:
+		err = fmt.Errorf("unsupported Apple search index variant: %s", variant)
+	}
+	if err != nil {
+		return ImportSearchIndexResult{}, err
+	}
+	assetByUUID, err := archiveAssetMap(ctx, archiveDB.DB())
+	if err != nil {
+		return ImportSearchIndexResult{}, err
+	}
+	peopleByUUID, err := loadPhotosPeopleByUUID(ctx, libraryPath)
+	if err != nil {
+		return ImportSearchIndexResult{}, err
+	}
+	tx, err := archiveDB.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return ImportSearchIndexResult{}, err
+	}
+	defer tx.Rollback()
+	if err := clearImportedSearchIndex(ctx, tx); err != nil {
+		return ImportSearchIndexResult{}, err
+	}
+
+	result := ImportSearchIndexResult{
+		Source:         photosSearchIndexSource,
+		Variant:        variant,
+		SearchDatabase: relPath,
+		Schema:         schema,
+		CategoriesSeen: map[string]int{},
+	}
+	touched := map[string]bool{}
+	unknownCategories := map[int]bool{}
+	importedAt := time.Now().UTC()
+	for _, row := range searchRows {
+		result.GroupsRead++
+		category := appleSearchCategoryForID(row.category)
+		categoryKey := fmt.Sprint(row.category)
+		result.CategoriesSeen[categoryKey]++
+		if category.Name == "UNKNOWN" {
+			result.UnknownCategoryRows++
+			unknownCategories[row.category] = true
+		} else {
+			result.KnownCategoryRows++
+		}
+
+		assetID, ok := assetByUUID[row.assetUUID]
+		if !ok {
+			result.GroupsUnresolved++
+			continue
+		}
+		person, hasPerson := peopleByUUID[strings.ToUpper(row.lookupIdentifier)]
+		if category.Name == "PERSON" {
+			if hasPerson {
+				result.PersonLookupIdentifiersResolved++
+			} else {
+				result.PersonLookupIdentifiersUnresolved++
+			}
+		}
+		if err := insertImportedSearchObservation(ctx, tx, assetID, row, category, person, hasPerson, importedAt); err != nil {
+			return ImportSearchIndexResult{}, err
+		}
+		result.GroupsResolved++
+		result.VisualObservationsInserted++
+		if category.Name == "PERSON" {
+			result.PersonFaceObservationsInserted++
+		}
+		touched[assetID] = true
+	}
+	if err := tx.Commit(); err != nil {
+		return ImportSearchIndexResult{}, err
+	}
+	result.AssetsTouched = len(touched)
+	for id := range unknownCategories {
+		result.UnknownCategories = append(result.UnknownCategories, id)
+	}
+	sort.Ints(result.UnknownCategories)
+	return result, nil
+}
+
+func resolveFacesLibraryPath(ctx context.Context, paths Paths, requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested != "" {
+		return requested, nil
+	}
+	db, err := store.OpenReadOnly(ctx, paths.Database)
+	if err == nil {
+		defer db.Close()
+		var libraryPath string
+		err = db.DB().QueryRowContext(ctx, `
+select library_path
+from source_library
+order by snapshot_created_at desc
+limit 1
+`).Scan(&libraryPath)
+		if err == nil && strings.TrimSpace(libraryPath) != "" {
+			return libraryPath, nil
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Pictures", "Photos Library.photoslibrary"), nil
+}
+
+func copyPhotosSQLite(liveDBPath string) (string, func(), error) {
+	return copySQLite(liveDBPath, "photoscrawl-faces-")
+}
+
+func copySQLite(liveDBPath string, tempPrefix string) (string, func(), error) {
+	dir, err := os.MkdirTemp("", tempPrefix)
+	if err != nil {
+		return "", func() {}, err
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	dest := filepath.Join(dir, filepath.Base(liveDBPath))
+	if err := copyFile(liveDBPath, dest, 0o600); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		source := liveDBPath + suffix
+		if _, err := os.Stat(source); err == nil {
+			if err := copyFile(source, dest+suffix, 0o600); err != nil {
+				cleanup()
+				return "", func() {}, err
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			cleanup()
+			return "", func() {}, err
+		}
+	}
+	return dest, cleanup, nil
+}
+
+func resolveAppleSearchDB(libraryPath string) (string, string, string, error) {
+	searchDir := filepath.Join(libraryPath, "database", "search")
+	candidates := []struct {
+		name    string
+		variant string
+	}{
+		{name: "psi.sqlite", variant: "psi"},
+		{name: "leo.sqlite", variant: "leo"},
+	}
+	for _, candidate := range candidates {
+		path := filepath.Join(searchDir, candidate.name)
+		info, err := os.Stat(path)
+		if err == nil && info.Size() > 0 {
+			return path, candidate.variant, filepath.Join("database", "search", candidate.name), nil
+		}
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return "", "", "", fmt.Errorf("inspect Apple search index %s: %w", path, err)
+		}
+	}
+	return "", "", "", fmt.Errorf("find Apple Photos search index: neither %s nor %s exists with content", filepath.Join(searchDir, "psi.sqlite"), filepath.Join(searchDir, "leo.sqlite"))
+}
+
+func copyFile(source, dest string, mode os.FileMode) error {
+	in, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", source, err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dest, err)
+	}
+	_, copyErr := io.Copy(out, in)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return fmt.Errorf("copy %s: %w", source, copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close %s: %w", dest, closeErr)
+	}
+	return nil
+}
+
+func validatePhotosFacesSchema(ctx context.Context, db *sql.DB) (map[string]string, error) {
+	required := map[string][]string{
+		"ZPERSON":       {"Z_PK", "ZDISPLAYNAME", "ZFULLNAME", "ZPERSONUUID"},
+		"ZDETECTEDFACE": {"Z_PK", "ZUUID", "ZPERSONFORFACE", "ZASSETFORFACE", "ZCENTERX", "ZCENTERY", "ZSIZE", "ZQUALITY", "ZNAMESOURCE", "ZCLOUDNAMESOURCE", "ZSOURCEWIDTH", "ZSOURCEHEIGHT"},
+		"ZASSET":        {"Z_PK", "ZUUID"},
+	}
+	out := map[string]string{}
+	for table, columns := range required {
+		existing, err := tableColumns(ctx, db, table)
+		if err != nil {
+			return nil, err
+		}
+		missing := []string{}
+		for _, column := range columns {
+			if !existing[column] {
+				missing = append(missing, column)
+			}
+		}
+		if len(missing) > 0 {
+			return nil, fmt.Errorf("Photos schema table %s missing columns: %s", table, strings.Join(missing, ", "))
+		}
+		out[table] = strings.Join(columns, ",")
+	}
+	return out, nil
+}
+
+func validatePSISearchSchema(ctx context.Context, db *sql.DB) (map[string]string, error) {
+	required := map[string][]string{
+		"assets": {"rowid", "uuid_0", "uuid_1"},
+		"groups": {"rowid", "category", "owning_groupid", "content_string", "normalized_string", "lookup_identifier", "score"},
+		"ga":     {"rowid", "assetid", "groupid"},
+	}
+	out := map[string]string{}
+	for table, columns := range required {
+		existing, err := tableColumns(ctx, db, table)
+		if err != nil {
+			return nil, err
+		}
+		missing := []string{}
+		for _, column := range columns {
+			if column == "rowid" {
+				continue
+			}
+			if !existing[column] {
+				missing = append(missing, column)
+			}
+		}
+		if len(missing) > 0 {
+			return nil, fmt.Errorf("Apple search index table %s missing columns: %s", table, strings.Join(missing, ", "))
+		}
+		out[table] = strings.Join(columns, ",")
+	}
+	return out, nil
+}
+
+func validateLeoSearchSchema(ctx context.Context, db *sql.DB) (map[string]string, error) {
+	required := map[string][]string{
+		"lexicon": {"lexeme_id", "type", "category", "content"},
+		"items":   {"identifier", "type", "lexeme_ids"},
+	}
+	out := map[string]string{}
+	for table, columns := range required {
+		existing, err := tableColumns(ctx, db, table)
+		if err != nil {
+			return nil, err
+		}
+		missing := []string{}
+		for _, column := range columns {
+			if !existing[column] {
+				missing = append(missing, column)
+			}
+		}
+		if len(missing) > 0 {
+			return nil, fmt.Errorf("Apple search index table %s missing columns: %s", table, strings.Join(missing, ", "))
+		}
+		out[table] = strings.Join(columns, ",")
+	}
+	return out, nil
+}
+
+func tableColumns(ctx context.Context, db *sql.DB, table string) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx, "pragma table_info("+store.QuoteIdent(table)+")")
+	if err != nil {
+		return nil, fmt.Errorf("inspect Photos schema %s: %w", table, err)
+	}
+	defer rows.Close()
+	columns := map[string]bool{}
+	for rows.Next() {
+		var cid int
+		var name, columnType string
+		var notNull, pk int
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &pk); err != nil {
+			return nil, err
+		}
+		columns[name] = true
+	}
+	return columns, rows.Err()
+}
+
+func archiveAssetMap(ctx context.Context, db *sql.DB) (map[string]string, error) {
+	rows, err := db.QueryContext(ctx, `select id, local_identifier from asset`)
+	if err != nil {
+		return nil, fmt.Errorf("load archive assets: %w", err)
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	for rows.Next() {
+		var assetID, localIdentifier string
+		if err := rows.Scan(&assetID, &localIdentifier); err != nil {
+			return nil, err
+		}
+		uuid := normalizeAssetLocalIdentifier(localIdentifier)
+		if uuid != "" {
+			out[uuid] = assetID
+		}
+	}
+	return out, rows.Err()
+}
+
+func normalizeAssetLocalIdentifier(localIdentifier string) string {
+	localIdentifier = strings.TrimSpace(localIdentifier)
+	if before, _, ok := strings.Cut(localIdentifier, "/"); ok {
+		return before
+	}
+	return localIdentifier
+}
+
+func loadPhotosFaceRows(ctx context.Context, db *sql.DB) ([]photosFaceRow, int, int, error) {
+	var namedPersons int
+	if err := db.QueryRowContext(ctx, `
+select count(*)
+from ZPERSON
+where trim(coalesce(ZDISPLAYNAME, ZFULLNAME, '')) <> ''
+`).Scan(&namedPersons); err != nil {
+		return nil, 0, 0, fmt.Errorf("count named Photos people: %w", err)
+	}
+	var unnamedFaces int
+	if err := db.QueryRowContext(ctx, `
+select count(*)
+from ZDETECTEDFACE f
+left join ZPERSON p on p.Z_PK = f.ZPERSONFORFACE
+where trim(coalesce(p.ZDISPLAYNAME, p.ZFULLNAME, '')) = ''
+`).Scan(&unnamedFaces); err != nil {
+		return nil, 0, 0, fmt.Errorf("count unnamed Photos faces: %w", err)
+	}
+
+	rows, err := db.QueryContext(ctx, `
+select f.Z_PK,
+       coalesce(f.ZUUID, ''),
+       coalesce(a.ZUUID, ''),
+       trim(coalesce(p.ZDISPLAYNAME, p.ZFULLNAME, '')),
+       coalesce(p.ZPERSONUUID, ''),
+       coalesce(f.ZNAMESOURCE, 0),
+       coalesce(f.ZCLOUDNAMESOURCE, 0),
+       cast(f.ZQUALITY as real),
+       cast(f.ZCENTERX as real),
+       cast(f.ZCENTERY as real),
+       cast(f.ZSIZE as real),
+       f.ZSOURCEWIDTH,
+       f.ZSOURCEHEIGHT
+from ZDETECTEDFACE f
+join ZPERSON p on p.Z_PK = f.ZPERSONFORFACE
+join ZASSET a on a.Z_PK = f.ZASSETFORFACE
+where trim(coalesce(p.ZDISPLAYNAME, p.ZFULLNAME, '')) <> ''
+  and coalesce(a.ZUUID, '') <> ''
+order by f.Z_PK
+`)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("load Photos named faces: %w", err)
+	}
+	defer rows.Close()
+	out := []photosFaceRow{}
+	for rows.Next() {
+		var row photosFaceRow
+		if err := rows.Scan(
+			&row.facePK,
+			&row.faceUUID,
+			&row.assetUUID,
+			&row.personLabel,
+			&row.personUUID,
+			&row.nameSource,
+			&row.cloudSource,
+			&row.quality,
+			&row.centerX,
+			&row.centerY,
+			&row.size,
+			&row.sourceWidth,
+			&row.sourceHeight,
+		); err != nil {
+			return nil, 0, 0, err
+		}
+		out = append(out, row)
+	}
+	return out, namedPersons, unnamedFaces, rows.Err()
+}
+
+func loadPhotosPeopleByUUID(ctx context.Context, libraryPath string) (map[string]photosPerson, error) {
+	liveDBPath := filepath.Join(libraryPath, "database", "Photos.sqlite")
+	if _, err := os.Stat(liveDBPath); err != nil {
+		return nil, fmt.Errorf("find Photos sqlite for people lookup: %w", err)
+	}
+	snapshotPath, cleanup, err := copyPhotosSQLite(liveDBPath)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	photosDB, err := store.OpenReadOnly(ctx, snapshotPath)
+	if err != nil {
+		return nil, fmt.Errorf("open copied Photos sqlite for people lookup: %w", err)
+	}
+	defer photosDB.Close()
+	if _, err := validatePhotosFacesSchema(ctx, photosDB.DB()); err != nil {
+		return nil, err
+	}
+	rows, err := photosDB.DB().QueryContext(ctx, `
+select coalesce(ZPERSONUUID, ''), coalesce(ZDISPLAYNAME, ''), coalesce(ZFULLNAME, '')
+from ZPERSON
+where coalesce(ZPERSONUUID, '') <> ''
+`)
+	if err != nil {
+		return nil, fmt.Errorf("load Photos people by UUID: %w", err)
+	}
+	defer rows.Close()
+	out := map[string]photosPerson{}
+	for rows.Next() {
+		var person photosPerson
+		if err := rows.Scan(&person.uuid, &person.displayName, &person.fullName); err != nil {
+			return nil, err
+		}
+		person.uuid = strings.ToUpper(stripAppleSearchString(person.uuid))
+		out[person.uuid] = person
+	}
+	return out, rows.Err()
+}
+
+func loadPSISearchRows(ctx context.Context, db *sql.DB) ([]appleSearchRow, error) {
+	rows, err := db.QueryContext(ctx, `
+select ga.rowid,
+       assets.uuid_0,
+       assets.uuid_1,
+       groups.rowid as groupid,
+       groups.category,
+       groups.owning_groupid,
+       coalesce(groups.content_string, ''),
+       coalesce(groups.normalized_string, ''),
+       coalesce(groups.lookup_identifier, ''),
+       cast(groups.score as real)
+from ga
+join groups on groups.rowid = ga.groupid
+join assets on ga.assetid = assets.rowid
+order by ga.rowid
+`)
+	if err != nil {
+		return nil, fmt.Errorf("load Apple search index rows: %w", err)
+	}
+	defer rows.Close()
+	out := []appleSearchRow{}
+	for rows.Next() {
+		var row appleSearchRow
+		if err := rows.Scan(
+			&row.gaRowID,
+			&row.uuid0,
+			&row.uuid1,
+			&row.groupID,
+			&row.category,
+			&row.owningGroupID,
+			&row.contentString,
+			&row.normalizedString,
+			&row.lookupIdentifier,
+			&row.score,
+		); err != nil {
+			return nil, err
+		}
+		row.assetUUID = psiIntsToUUID(row.uuid0, row.uuid1)
+		row.searchVariant = "psi"
+		row.contentString = stripAppleSearchString(row.contentString)
+		row.normalizedString = stripAppleSearchString(row.normalizedString)
+		row.lookupIdentifier = stripAppleSearchString(row.lookupIdentifier)
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+type leoLexeme struct {
+	category int
+	content  string
+}
+
+func loadLeoSearchRows(ctx context.Context, db *sql.DB) ([]appleSearchRow, error) {
+	lexemeRows, err := db.QueryContext(ctx, `
+select lexeme_id, type, category, coalesce(content, '')
+from lexicon
+order by lexeme_id
+`)
+	if err != nil {
+		return nil, fmt.Errorf("load Apple leo lexicon: %w", err)
+	}
+	lexemes := map[uint32]leoLexeme{}
+	for lexemeRows.Next() {
+		var id uint32
+		var lexemeType, category int
+		var content string
+		if err := lexemeRows.Scan(&id, &lexemeType, &category, &content); err != nil {
+			lexemeRows.Close()
+			return nil, err
+		}
+		mappedCategory, ok := leoCategoryToPhotos8(category)
+		content = stripAppleSearchString(content)
+		if ok && lexemeType == 1 && content != "" {
+			lexemes[id] = leoLexeme{category: mappedCategory, content: content}
+		}
+	}
+	if err := lexemeRows.Close(); err != nil {
+		return nil, err
+	}
+	if err := lexemeRows.Err(); err != nil {
+		return nil, err
+	}
+
+	itemRows, err := db.QueryContext(ctx, `
+select rowid, coalesce(identifier, ''), lexeme_ids
+from items
+where type = 1
+order by rowid
+`)
+	if err != nil {
+		return nil, fmt.Errorf("load Apple leo items: %w", err)
+	}
+	defer itemRows.Close()
+	out := []appleSearchRow{}
+	var observationRowID int64
+	for itemRows.Next() {
+		var itemRowID int64
+		var identifier string
+		var lexemeIDs []byte
+		if err := itemRows.Scan(&itemRowID, &identifier, &lexemeIDs); err != nil {
+			return nil, err
+		}
+		assetUUID := strings.ToUpper(stripAppleSearchString(identifier))
+		if assetUUID == "" {
+			continue
+		}
+		for _, lexemeID := range decodeLeoLexemeIDs(lexemeIDs) {
+			lexeme, ok := lexemes[lexemeID]
+			if !ok {
+				continue
+			}
+			observationRowID++
+			out = append(out, appleSearchRow{
+				searchVariant:    "leo",
+				gaRowID:          observationRowID,
+				assetUUID:        assetUUID,
+				groupID:          int64(lexemeID),
+				category:         lexeme.category,
+				contentString:    lexeme.content,
+				normalizedString: strings.ToLower(lexeme.content),
+			})
+		}
+	}
+	return out, itemRows.Err()
+}
+
+func decodeLeoLexemeIDs(data []byte) []uint32 {
+	count := len(data) / 4
+	out := make([]uint32, 0, count)
+	for offset := 0; offset+4 <= len(data); offset += 4 {
+		out = append(out, binary.LittleEndian.Uint32(data[offset:offset+4]))
+	}
+	return out
+}
+
+func leoCategoryToPhotos8(category int) (int, bool) {
+	// Apple changed category ids with leo.sqlite. Keep this mapping aligned with
+	// osxphotos/photosdb/_photosdb_process_searchinfo.py:LEO_CATEGORY_TO_PHOTOS8.
+	mapped, ok := map[int]int{
+		1010: 1100,
+		1020: 1101,
+		1030: 1103,
+		1040: 1104,
+		1050: 1106,
+		1060: 1107,
+		2030: 1701,
+		2050: 2,
+		2060: 1,
+		2070: 3,
+		2090: 5,
+		2110: 7,
+		2140: 10,
+		2150: 11,
+		2160: 12,
+		3001: 1300,
+		4000: 1500,
+		4010: 1510,
+		4120: 1203,
+		5000: 1900,
+		5020: 1902,
+		6000: 2300,
+		7000: 1201,
+		7010: 1400,
+		8000: 2000,
+		8050: 2100,
+		8070: 1200,
+		8080: 1202,
+	}[category]
+	return mapped, ok
+}
+
+func clearImportedFaces(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `
+delete from observation_fts
+where id in (
+  select id from face_observation where source = ?
+)
+`, photosLibraryDBFaceSource); err != nil {
+		return fmt.Errorf("clear imported face fts: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `delete from face_observation where source = ?`, photosLibraryDBFaceSource); err != nil {
+		return fmt.Errorf("clear imported faces: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `delete from evidence_ref where source = ? and evidence_kind = ?`, photosLibraryDBFaceSource, "face_observation"); err != nil {
+		return fmt.Errorf("clear imported face evidence: %w", err)
+	}
+	return nil
+}
+
+func clearImportedSearchIndex(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `
+delete from observation_fts
+where id in (
+  select id from visual_observation where source = ?
+  union
+  select id from face_observation where source = ?
+)
+`, photosSearchIndexSource, photosSearchIndexSource); err != nil {
+		return fmt.Errorf("clear Apple search index fts: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `delete from visual_observation where source = ?`, photosSearchIndexSource); err != nil {
+		return fmt.Errorf("clear Apple search index visual observations: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `delete from face_observation where source = ?`, photosSearchIndexSource); err != nil {
+		return fmt.Errorf("clear Apple search index person observations: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `delete from evidence_ref where source = ? and evidence_kind = ?`, photosSearchIndexSource, "apple_search_index"); err != nil {
+		return fmt.Errorf("clear Apple search index evidence: %w", err)
+	}
+	return nil
+}
+
+func insertImportedFace(ctx context.Context, tx *sql.Tx, assetID string, face photosFaceRow, importedAt time.Time) error {
+	faceLocalID := face.faceUUID
+	if strings.TrimSpace(faceLocalID) == "" {
+		faceLocalID = fmt.Sprintf("ZDETECTEDFACE:%d", face.facePK)
+	}
+	observationID := stableID("face_observation", assetID, photosLibraryDBFaceSource, faceLocalID, face.personLabel)
+	evidenceID := stableID("evidence", assetID, photosLibraryDBFaceSource, faceLocalID)
+	boundingJSON, err := jsonText(faceBoundingBox(face))
+	if err != nil {
+		return err
+	}
+	evidenceJSON, err := jsonText(map[string]any{
+		"schema_source":     "Photos.sqlite",
+		"face_table":        "ZDETECTEDFACE",
+		"person_table":      "ZPERSON",
+		"asset_table":       "ZASSET",
+		"face_pk":           face.facePK,
+		"face_uuid":         face.faceUUID,
+		"asset_uuid":        face.assetUUID,
+		"person_uuid":       face.personUUID,
+		"name_source":       face.nameSource,
+		"cloud_name_source": face.cloudSource,
+		"quality":           nullableSQLFloat(face.quality),
+		"imported_at":       importedAt.Format(time.RFC3339Nano),
+		"read_only":         true,
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+insert into evidence_ref(id, asset_id, evidence_kind, source, pointer, value_json)
+values (?, ?, ?, ?, ?, ?)
+`, evidenceID, assetID, "face_observation", photosLibraryDBFaceSource, fmt.Sprintf("ZDETECTEDFACE:%d", face.facePK), evidenceJSON); err != nil {
+		return fmt.Errorf("write imported face evidence: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+insert into face_observation(id, asset_id, face_local_id, person_label, confidence, bounding_box_json, source, evidence_id)
+values (?, ?, ?, ?, ?, ?, ?, ?)
+`, observationID, assetID, faceLocalID, face.personLabel, 1.0, boundingJSON, photosLibraryDBFaceSource, evidenceID); err != nil {
+		return fmt.Errorf("write imported face observation: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+insert into observation_fts(id, asset_id, title, body)
+values (?, ?, ?, ?)
+`, observationID, assetID, face.personLabel, strings.Join(nonEmpty("person", "face", face.personLabel, photosLibraryDBFaceSource), " ")); err != nil {
+		return fmt.Errorf("write imported face fts: %w", err)
+	}
+	return nil
+}
+
+func insertImportedSearchObservation(ctx context.Context, tx *sql.Tx, assetID string, row appleSearchRow, category appleSearchCategory, person photosPerson, hasPerson bool, importedAt time.Time) error {
+	label := row.contentString
+	if strings.TrimSpace(label) == "" {
+		label = row.normalizedString
+	}
+	if strings.TrimSpace(label) == "" {
+		label = row.lookupIdentifier
+	}
+	if strings.TrimSpace(label) == "" {
+		label = fmt.Sprintf("category-%d-group-%d", row.category, row.groupID)
+	}
+	confidence := 1.0
+	if row.score.Valid && row.score.Float64 > 0 {
+		confidence = row.score.Float64
+	}
+	searchVariant := row.searchVariant
+	if searchVariant == "" {
+		searchVariant = "psi"
+	}
+	searchDatabase := "database/search/" + searchVariant + ".sqlite"
+	evidenceID := stableID("evidence", assetID, photosSearchIndexSource, fmt.Sprint(row.gaRowID), fmt.Sprint(row.groupID))
+	evidenceJSON, err := jsonText(map[string]any{
+		"schema_source":              searchDatabase,
+		"table":                      map[string]string{"psi": "ga", "leo": "items"}[searchVariant],
+		"ga_rowid":                   row.gaRowID,
+		"groupid":                    row.groupID,
+		"category_id":                row.category,
+		"category_name":              category.Name,
+		"semantic_kind":              category.SemanticKind,
+		"owning_groupid":             nullableSQLInt(row.owningGroupID),
+		"content_string":             row.contentString,
+		"normalized_string":          row.normalizedString,
+		"lookup_identifier":          row.lookupIdentifier,
+		"score":                      nullableSQLFloat(row.score),
+		"asset_uuid":                 row.assetUUID,
+		"uuid_0":                     row.uuid0,
+		"uuid_1":                     row.uuid1,
+		"person_lookup_joined":       hasPerson,
+		"person_lookup_display_name": person.displayName,
+		"person_lookup_full_name":    person.fullName,
+		"imported_at":                importedAt.Format(time.RFC3339Nano),
+		"read_only":                  true,
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+insert into evidence_ref(id, asset_id, evidence_kind, source, pointer, value_json)
+values (?, ?, ?, ?, ?, ?)
+`, evidenceID, assetID, "apple_search_index", photosSearchIndexSource, fmt.Sprintf("%s:%d:group:%d:category:%d", searchDatabase, row.gaRowID, row.groupID, row.category), evidenceJSON); err != nil {
+		return fmt.Errorf("write Apple search index evidence: %w", err)
+	}
+	observationID := stableID("visual_observation", assetID, photosSearchIndexSource, fmt.Sprint(row.gaRowID), fmt.Sprint(row.groupID), label)
+	if _, err := tx.ExecContext(ctx, `
+insert into visual_observation(id, asset_id, observation_type, label, confidence, bounding_box_json, source, model_id, evidence_id)
+values (?, ?, ?, ?, ?, '{}', ?, ?, ?)
+`, observationID, assetID, category.SemanticKind, label, confidence, photosSearchIndexSource, photosSearchIndexModelID, evidenceID); err != nil {
+		return fmt.Errorf("write Apple search index visual observation: %w", err)
+	}
+	body := strings.Join(nonEmpty(category.SemanticKind, category.Name, label, row.normalizedString, row.lookupIdentifier, photosSearchIndexSource), " ")
+	if _, err := tx.ExecContext(ctx, `
+insert into observation_fts(id, asset_id, title, body)
+values (?, ?, ?, ?)
+`, observationID, assetID, label, body); err != nil {
+		return fmt.Errorf("write Apple search index fts: %w", err)
+	}
+	if category.Name != "PERSON" {
+		return nil
+	}
+	faceLocalID := "psi:person:" + row.lookupIdentifier
+	if strings.TrimSpace(row.lookupIdentifier) == "" {
+		faceLocalID = fmt.Sprintf("psi:person:group:%d", row.groupID)
+	}
+	faceObservationID := stableID("face_observation", assetID, photosSearchIndexSource, faceLocalID, label, fmt.Sprint(row.gaRowID))
+	if _, err := tx.ExecContext(ctx, `
+insert into face_observation(id, asset_id, face_local_id, person_label, confidence, bounding_box_json, source, evidence_id)
+values (?, ?, ?, ?, ?, '{}', ?, ?)
+`, faceObservationID, assetID, faceLocalID, label, confidence, photosSearchIndexSource, evidenceID); err != nil {
+		return fmt.Errorf("write Apple search index person observation: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+insert into observation_fts(id, asset_id, title, body)
+values (?, ?, ?, ?)
+`, faceObservationID, assetID, label, strings.Join(nonEmpty("person", "face", "apple_search_index", label, row.lookupIdentifier), " ")); err != nil {
+		return fmt.Errorf("write Apple search index person fts: %w", err)
+	}
+	return nil
+}
+
+func appleSearchCategoryForID(id int) appleSearchCategory {
+	if category, ok := appleSearchCategoriesPhotos8()[id]; ok {
+		return category
+	}
+	return appleSearchCategory{ID: id, Name: "UNKNOWN", SemanticKind: fmt.Sprintf("apple_search_category_%d", id)}
+}
+
+// Category ids come from osxphotos/_constants.py:SearchCategory_Photos8.
+// Missing ids deliberately fall through to UNKNOWN so new Apple categories still import.
+func appleSearchCategoriesPhotos8() map[int]appleSearchCategory {
+	categories := map[int]appleSearchCategory{
+		1:    {ID: 1, Name: "PLACE_NAME", SemanticKind: "apple_place"},
+		2:    {ID: 2, Name: "STREET", SemanticKind: "apple_place"},
+		3:    {ID: 3, Name: "NEIGHBORHOOD", SemanticKind: "apple_place"},
+		4:    {ID: 4, Name: "LOCALITY_4", SemanticKind: "apple_place"},
+		5:    {ID: 5, Name: "CITY", SemanticKind: "apple_place"},
+		6:    {ID: 6, Name: "SUB_LOCALITY_6", SemanticKind: "apple_place"},
+		7:    {ID: 7, Name: "NAMED_AREA", SemanticKind: "apple_place"},
+		8:    {ID: 8, Name: "LOCALITY_8", SemanticKind: "apple_place"},
+		10:   {ID: 10, Name: "STATE", SemanticKind: "apple_place"},
+		11:   {ID: 11, Name: "STATE_ABBREVIATION", SemanticKind: "apple_place"},
+		12:   {ID: 12, Name: "COUNTRY", SemanticKind: "apple_place"},
+		14:   {ID: 14, Name: "BODY_OF_WATER", SemanticKind: "apple_place"},
+		1000: {ID: 1000, Name: "HOME", SemanticKind: "apple_place"},
+		1001: {ID: 1001, Name: "WORK", SemanticKind: "apple_place"},
+		1100: {ID: 1100, Name: "MONTH", SemanticKind: "apple_date"},
+		1101: {ID: 1101, Name: "YEAR", SemanticKind: "apple_date"},
+		1103: {ID: 1103, Name: "HOLIDAY", SemanticKind: "apple_date"},
+		1104: {ID: 1104, Name: "SEASON", SemanticKind: "apple_date"},
+		1106: {ID: 1106, Name: "TIME_OF_DAY", SemanticKind: "apple_date"},
+		1107: {ID: 1107, Name: "WEEKPART", SemanticKind: "apple_date"},
+		1200: {ID: 1200, Name: "KEYWORDS", SemanticKind: "apple_keyword"},
+		1201: {ID: 1201, Name: "TITLE", SemanticKind: "apple_title"},
+		1202: {ID: 1202, Name: "DESCRIPTION", SemanticKind: "apple_description"},
+		1203: {ID: 1203, Name: "DETECTED_TEXT", SemanticKind: "apple_text"},
+		1205: {ID: 1205, Name: "TEXT_FOUND", SemanticKind: "apple_text"},
+		1300: {ID: 1300, Name: "PERSON", SemanticKind: "apple_person"},
+		1400: {ID: 1400, Name: "ALBUM", SemanticKind: "apple_album"},
+		1500: {ID: 1500, Name: "LABEL", SemanticKind: "apple_label"},
+		1510: {ID: 1510, Name: "RICH_LABEL", SemanticKind: "apple_label"},
+		1600: {ID: 1600, Name: "ACTIVITY", SemanticKind: "apple_activity"},
+		1700: {ID: 1700, Name: "VENUE", SemanticKind: "apple_venue"},
+		1701: {ID: 1701, Name: "VENUE_TYPE", SemanticKind: "apple_venue"},
+		1900: {ID: 1900, Name: "PHOTO_TYPE_PHOTO", SemanticKind: "apple_media_type"},
+		1901: {ID: 1901, Name: "PHOTO_TYPE_VIDEO", SemanticKind: "apple_media_type"},
+		1902: {ID: 1902, Name: "PHOTO_TYPE_RAW", SemanticKind: "apple_media_type"},
+		1905: {ID: 1905, Name: "PHOTO_TYPE_SLOMO", SemanticKind: "apple_media_type"},
+		1906: {ID: 1906, Name: "PHOTO_TYPE_LIVE", SemanticKind: "apple_media_type"},
+		1907: {ID: 1907, Name: "PHOTO_TYPE_SCREENSHOT", SemanticKind: "apple_media_type"},
+		1908: {ID: 1908, Name: "PHOTO_TYPE_PANORAMA", SemanticKind: "apple_media_type"},
+		1909: {ID: 1909, Name: "PHOTO_TYPE_TIMELAPSE", SemanticKind: "apple_media_type"},
+		1912: {ID: 1912, Name: "PHOTO_TYPE_ANIMATED", SemanticKind: "apple_media_type"},
+		1913: {ID: 1913, Name: "PHOTO_TYPE_BURSTS", SemanticKind: "apple_media_type"},
+		1914: {ID: 1914, Name: "PHOTO_TYPE_PORTRAIT", SemanticKind: "apple_media_type"},
+		1915: {ID: 1915, Name: "PHOTO_TYPE_SELFIES", SemanticKind: "apple_media_type"},
+		1916: {ID: 1916, Name: "PHOTO_TYPE_SCREENRECORDINGS", SemanticKind: "apple_media_type"},
+		2000: {ID: 2000, Name: "PHOTO_TYPE_FAVORITES", SemanticKind: "apple_media_type"},
+		2100: {ID: 2100, Name: "PHOTO_NAME", SemanticKind: "apple_photo_name"},
+		2200: {ID: 2200, Name: "SOURCE", SemanticKind: "apple_source"},
+		2300: {ID: 2300, Name: "CAMERA", SemanticKind: "apple_camera"},
+	}
+	return categories
+}
+
+func psiIntsToUUID(uuid0, uuid1 int64) string {
+	var bytes [16]byte
+	binary.LittleEndian.PutUint64(bytes[0:8], uint64(uuid0))
+	binary.LittleEndian.PutUint64(bytes[8:16], uint64(uuid1))
+	return fmt.Sprintf("%X-%X-%X-%X-%X", bytes[0:4], bytes[4:6], bytes[6:8], bytes[8:10], bytes[10:16])
+}
+
+func stripAppleSearchString(value string) string {
+	return strings.TrimSpace(strings.ReplaceAll(value, "\x00", ""))
+}
+
+func faceBoundingBox(face photosFaceRow) map[string]any {
+	out := map[string]any{"coordinate_space": "photos_normalized_center_size"}
+	if face.centerX.Valid {
+		out["center_x"] = face.centerX.Float64
+	}
+	if face.centerY.Valid {
+		out["center_y"] = face.centerY.Float64
+	}
+	if face.size.Valid {
+		out["size"] = face.size.Float64
+	}
+	if face.sourceWidth.Valid {
+		out["source_width"] = face.sourceWidth.Int64
+	}
+	if face.sourceHeight.Valid {
+		out["source_height"] = face.sourceHeight.Int64
+	}
+	return out
+}
+
+func nullableSQLFloat(value sql.NullFloat64) any {
+	if !value.Valid {
+		return nil
+	}
+	return value.Float64
+}
+
+func nullableSQLInt(value sql.NullInt64) any {
+	if !value.Valid {
+		return nil
+	}
+	return value.Int64
+}

--- a/internal/archive/faces_test.go
+++ b/internal/archive/faces_test.go
@@ -162,6 +162,51 @@ select value, side, zeroblob(2048) from batches cross join (select 1 as side uni
 	}
 }
 
+func TestImportApplePreflightFailureLeavesExistingObservations(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	paths := Paths{DataDir: root, Database: filepath.Join(root, "photos.sqlite")}
+	archiveDB, err := store.Open(ctx, store.Options{Path: paths.Database, Schema: Schema, SchemaVersion: SchemaVersion})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceID := stableID("source_library", "test-library")
+	assetID := stableID("asset", sourceID, "92D69D06-27F0-4831-AEC7-C6F640F075BA/L0/001")
+	execTestSQL(t, archiveDB.DB(), `
+insert into source_library(id, library_path, snapshot_path, snapshot_created_at, photos_version, metadata_json)
+values (?, ?, ?, ?, ?, '{}')
+`, sourceID, filepath.Join(root, "Library.photoslibrary"), "snapshot", "2026-07-06T00:00:00Z", "test")
+	execTestSQL(t, archiveDB.DB(), `
+insert into asset(id, local_identifier, media_type, media_subtypes, creation_date, modification_date, added_date, timezone_name, width, height, duration_seconds, favorite, hidden, burst_identifier, represents_burst, source_library_id, metadata_json)
+values (?, ?, 'image', '', '2026-07-06T00:00:00Z', '', '', '', 100, 100, 0, 0, 0, '', 0, ?, '{}')
+`, assetID, "92D69D06-27F0-4831-AEC7-C6F640F075BA/L0/001", sourceID)
+	execTestSQL(t, archiveDB.DB(), `
+insert into face_observation(id, asset_id, face_local_id, person_label, confidence, bounding_box_json, source, evidence_id)
+values ('existing-face', ?, 'existing', 'Existing Person', 1, '{}', ?, 'existing-face-evidence')
+`, assetID, photosLibraryDBFaceSource)
+	execTestSQL(t, archiveDB.DB(), `
+insert into visual_observation(id, asset_id, observation_type, label, confidence, bounding_box_json, source, model_id, evidence_id)
+values ('existing-search', ?, 'apple_label', 'Existing Label', 1, '{}', ?, ?, 'existing-search-evidence')
+`, assetID, photosSearchIndexSource, photosSearchIndexModelID)
+	if err := archiveDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	libraryPath := filepath.Join(root, "Library.photoslibrary")
+	createTestPhotosDB(t, filepath.Join(libraryPath, "database", "Photos.sqlite"))
+	if _, err := ImportApple(ctx, paths, ImportAppleOptions{LibraryPath: libraryPath}); err == nil {
+		t.Fatal("ImportApple() succeeded without a search index")
+	}
+
+	archiveDB, err = store.OpenReadOnly(ctx, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer archiveDB.Close()
+	assertCount(t, archiveDB.DB(), `select count(*) from face_observation where id = 'existing-face' and person_label = 'Existing Person'`, 1)
+	assertCount(t, archiveDB.DB(), `select count(*) from visual_observation where id = 'existing-search' and label = 'Existing Label'`, 1)
+}
+
 func TestImportSearchIndexIsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
@@ -202,6 +247,13 @@ values (?, ?, 'image', '', '2026-07-06T00:00:00Z', '', '', '', 100, 100, 0, 0, 0
 	second, err := ImportSearchIndex(ctx, paths, ImportSearchIndexOptions{LibraryPath: libraryPath})
 	if err != nil {
 		t.Fatal(err)
+	}
+	combined, err := ImportApple(ctx, paths, ImportAppleOptions{LibraryPath: libraryPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if combined.SyncStrategy != "atomic_authoritative_replace_by_source" || combined.TotalAssetsTouched != 1 {
+		t.Fatalf("combined import = %#v", combined)
 	}
 	if first.GroupsRead != 3 || first.VisualObservationsInserted != 3 || first.PersonFaceObservationsInserted != 1 {
 		t.Fatalf("first import counts = %#v", first)

--- a/internal/archive/faces_test.go
+++ b/internal/archive/faces_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/openclaw/crawlkit/store"
 )
@@ -80,6 +81,84 @@ func TestDecodeLeoLexemeIDs(t *testing.T) {
 	got := decodeLeoLexemeIDs([]byte{1, 0, 0, 0, 42, 0, 0, 0, 255})
 	if len(got) != 2 || got[0] != 1 || got[1] != 42 {
 		t.Fatalf("decodeLeoLexemeIDs() = %#v", got)
+	}
+}
+
+func TestCopySQLiteCreatesConsistentSnapshotWhileSourceIsLive(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "live.sqlite")
+	db, err := sql.Open("sqlite", "file:"+sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(ctx, `
+pragma journal_mode = wal;
+pragma wal_autocheckpoint = 0;
+create table paired(batch integer not null, side integer not null, payload blob, primary key(batch, side));
+with recursive batches(value) as (select 1 union all select value + 1 from batches where value < 2000)
+insert into paired(batch, side, payload)
+select value, side, zeroblob(2048) from batches cross join (select 1 as side union all select 2);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	writerDone := make(chan error, 1)
+	writerStarted := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		for batch := 2001; batch <= 2100; batch++ {
+			tx, err := db.BeginTx(ctx, nil)
+			if err == nil {
+				_, err = tx.ExecContext(ctx, `insert into paired(batch, side, payload) values (?, 1, zeroblob(2048)), (?, 2, zeroblob(2048))`, batch, batch)
+			}
+			if err == nil {
+				err = tx.Commit()
+			} else if tx != nil {
+				_ = tx.Rollback()
+			}
+			if err != nil {
+				writerDone <- err
+				return
+			}
+			if batch == 2001 {
+				close(writerStarted)
+			}
+			time.Sleep(100 * time.Microsecond)
+		}
+		writerDone <- nil
+	}()
+	<-writerStarted
+
+	snapshotPath, cleanup, copyErr := copySQLite(ctx, sourcePath, "photoscrawl-snapshot-test-")
+	if writerErr := <-writerDone; writerErr != nil {
+		t.Fatal(writerErr)
+	}
+	if copyErr != nil {
+		t.Fatal(copyErr)
+	}
+	defer cleanup()
+
+	snapshot, err := store.OpenReadOnly(ctx, snapshotPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer snapshot.Close()
+	var integrity string
+	if err := snapshot.DB().QueryRowContext(ctx, `pragma integrity_check`).Scan(&integrity); err != nil {
+		t.Fatal(err)
+	}
+	if integrity != "ok" {
+		t.Fatalf("snapshot integrity = %q", integrity)
+	}
+	var incompleteBatches int
+	if err := snapshot.DB().QueryRowContext(ctx, `select count(*) from (select batch from paired group by batch having count(*) <> 2)`).Scan(&incompleteBatches); err != nil {
+		t.Fatal(err)
+	}
+	if incompleteBatches != 0 {
+		t.Fatalf("snapshot contains %d partial write batches", incompleteBatches)
 	}
 }
 

--- a/internal/archive/faces_test.go
+++ b/internal/archive/faces_test.go
@@ -1,0 +1,284 @@
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/crawlkit/store"
+)
+
+func TestNormalizeAssetLocalIdentifier(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "photokit identifier",
+			input: "D4AA1B8D-FABB-428A-A001-1E285D0CC1EC/L0/001",
+			want:  "D4AA1B8D-FABB-428A-A001-1E285D0CC1EC",
+		},
+		{
+			name:  "sqlite snapshot uuid",
+			input: "D4AA1B8D-FABB-428A-A001-1E285D0CC1EC",
+			want:  "D4AA1B8D-FABB-428A-A001-1E285D0CC1EC",
+		},
+		{
+			name:  "trim whitespace",
+			input: "  D4AA1B8D-FABB-428A-A001-1E285D0CC1EC/L0/001  ",
+			want:  "D4AA1B8D-FABB-428A-A001-1E285D0CC1EC",
+		},
+		{
+			name:  "empty",
+			input: " ",
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeAssetLocalIdentifier(tt.input); got != tt.want {
+				t.Fatalf("normalizeAssetLocalIdentifier(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppleSearchCategoryMapping(t *testing.T) {
+	person := appleSearchCategoryForID(1300)
+	if person.Name != "PERSON" || person.SemanticKind != "apple_person" {
+		t.Fatalf("person category = %#v", person)
+	}
+	label := appleSearchCategoryForID(1500)
+	if label.Name != "LABEL" || label.SemanticKind != "apple_label" {
+		t.Fatalf("label category = %#v", label)
+	}
+	unknown := appleSearchCategoryForID(9999)
+	if unknown.Name != "UNKNOWN" || unknown.SemanticKind != "apple_search_category_9999" {
+		t.Fatalf("unknown category = %#v", unknown)
+	}
+}
+
+func TestPSIIntsToUUID(t *testing.T) {
+	got := psiIntsToUUID(3551352356587034258, -5010834848571013202)
+	want := "92D69D06-27F0-4831-AEC7-C6F640F075BA"
+	if got != want {
+		t.Fatalf("psiIntsToUUID() = %q, want %q", got, want)
+	}
+}
+
+func TestStripAppleSearchString(t *testing.T) {
+	got := stripAppleSearchString(" Antique Car\x00 ")
+	if got != "Antique Car" {
+		t.Fatalf("stripAppleSearchString() = %q", got)
+	}
+}
+
+func TestDecodeLeoLexemeIDs(t *testing.T) {
+	got := decodeLeoLexemeIDs([]byte{1, 0, 0, 0, 42, 0, 0, 0, 255})
+	if len(got) != 2 || got[0] != 1 || got[1] != 42 {
+		t.Fatalf("decodeLeoLexemeIDs() = %#v", got)
+	}
+}
+
+func TestImportSearchIndexIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	paths := Paths{DataDir: root, Database: filepath.Join(root, "photos.sqlite")}
+	archiveDB, err := store.Open(ctx, store.Options{Path: paths.Database, Schema: Schema, SchemaVersion: SchemaVersion})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceID := stableID("source_library", "test-library")
+	assetID := stableID("asset", sourceID, "92D69D06-27F0-4831-AEC7-C6F640F075BA/L0/001")
+	execTestSQL(t, archiveDB.DB(), `
+insert into source_library(id, library_path, snapshot_path, snapshot_created_at, photos_version, metadata_json)
+values (?, ?, ?, ?, ?, '{}')
+`, sourceID, filepath.Join(root, "Library.photoslibrary"), "snapshot", "2026-07-06T00:00:00Z", "test")
+	execTestSQL(t, archiveDB.DB(), `
+insert into asset(id, local_identifier, media_type, media_subtypes, creation_date, modification_date, added_date, timezone_name, width, height, duration_seconds, favorite, hidden, burst_identifier, represents_burst, source_library_id, metadata_json)
+values (?, ?, 'image', '', '2026-07-06T00:00:00Z', '', '', '', 100, 100, 0, 0, 0, '', 0, ?, '{}')
+`, assetID, "92D69D06-27F0-4831-AEC7-C6F640F075BA/L0/001", sourceID)
+	if err := archiveDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	libraryPath := filepath.Join(root, "Library.photoslibrary")
+	createTestPhotosDB(t, filepath.Join(libraryPath, "database", "Photos.sqlite"))
+	createTestPSIDB(t, filepath.Join(libraryPath, "database", "search", "psi.sqlite"))
+	faces, err := ImportFaces(ctx, paths, ImportFacesOptions{LibraryPath: libraryPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if faces.FaceObservationsInserted != 1 || faces.AssetsTouched != 1 || faces.NamedPersonsFound != 1 {
+		t.Fatalf("face import counts = %#v", faces)
+	}
+
+	first, err := ImportSearchIndex(ctx, paths, ImportSearchIndexOptions{LibraryPath: libraryPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ImportSearchIndex(ctx, paths, ImportSearchIndexOptions{LibraryPath: libraryPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.GroupsRead != 3 || first.VisualObservationsInserted != 3 || first.PersonFaceObservationsInserted != 1 {
+		t.Fatalf("first import counts = %#v", first)
+	}
+	if first.PersonLookupIdentifiersResolved != 1 || first.PersonLookupIdentifiersUnresolved != 0 {
+		t.Fatalf("person lookup counts = resolved %d unresolved %d", first.PersonLookupIdentifiersResolved, first.PersonLookupIdentifiersUnresolved)
+	}
+	if first.KnownCategoryRows != 2 || first.UnknownCategoryRows != 1 || len(first.UnknownCategories) != 1 || first.UnknownCategories[0] != 9999 {
+		t.Fatalf("category counts = known %d unknown %d unknown ids %#v", first.KnownCategoryRows, first.UnknownCategoryRows, first.UnknownCategories)
+	}
+	if first.CategoriesSeen["1500"] != 1 || first.CategoriesSeen["1300"] != 1 || first.CategoriesSeen["9999"] != 1 {
+		t.Fatalf("categories seen = %#v", first.CategoriesSeen)
+	}
+	if second.GroupsRead != first.GroupsRead || second.VisualObservationsInserted != first.VisualObservationsInserted || second.PersonFaceObservationsInserted != first.PersonFaceObservationsInserted {
+		t.Fatalf("second import counts = %#v, first %#v", second, first)
+	}
+
+	archiveDB, err = store.OpenReadOnly(ctx, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer archiveDB.Close()
+	assertCount(t, archiveDB.DB(), `select count(*) from visual_observation where source = ?`, 3, photosSearchIndexSource)
+	assertCount(t, archiveDB.DB(), `select count(*) from face_observation where source = ?`, 1, photosSearchIndexSource)
+	assertCount(t, archiveDB.DB(), `select count(*) from evidence_ref where source = ? and evidence_kind = 'apple_search_index'`, 3, photosSearchIndexSource)
+	assertCount(t, archiveDB.DB(), `select count(*) from observation_fts where asset_id = ?`, 5, assetID)
+	status, err := Status(ctx, paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasStatusCount(status.Counts, "observation.source.photos_search_index") {
+		t.Fatalf("status counts missing Apple search source: %#v", status.Counts)
+	}
+}
+
+func TestImportLeoSearchIndexIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	paths := Paths{DataDir: root, Database: filepath.Join(root, "photos.sqlite")}
+	archiveDB, err := store.Open(ctx, store.Options{Path: paths.Database, Schema: Schema, SchemaVersion: SchemaVersion})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceID := stableID("source_library", "test-library")
+	assetID := stableID("asset", sourceID, "92D69D06-27F0-4831-AEC7-C6F640F075BA/L0/001")
+	execTestSQL(t, archiveDB.DB(), `
+insert into source_library(id, library_path, snapshot_path, snapshot_created_at, photos_version, metadata_json)
+values (?, ?, ?, ?, ?, '{}')
+`, sourceID, filepath.Join(root, "Library.photoslibrary"), "snapshot", "2026-07-06T00:00:00Z", "test")
+	execTestSQL(t, archiveDB.DB(), `
+insert into asset(id, local_identifier, media_type, media_subtypes, creation_date, modification_date, added_date, timezone_name, width, height, duration_seconds, favorite, hidden, burst_identifier, represents_burst, source_library_id, metadata_json)
+values (?, ?, 'image', '', '2026-07-06T00:00:00Z', '', '', '', 100, 100, 0, 0, 0, '', 0, ?, '{}')
+`, assetID, "92D69D06-27F0-4831-AEC7-C6F640F075BA/L0/001", sourceID)
+	if err := archiveDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	libraryPath := filepath.Join(root, "Library.photoslibrary")
+	createTestPhotosDB(t, filepath.Join(libraryPath, "database", "Photos.sqlite"))
+	createTestLeoDB(t, filepath.Join(libraryPath, "database", "search", "leo.sqlite"))
+
+	first, err := ImportSearchIndex(ctx, paths, ImportSearchIndexOptions{LibraryPath: libraryPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ImportSearchIndex(ctx, paths, ImportSearchIndexOptions{LibraryPath: libraryPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Variant != "leo" || first.GroupsRead != 2 || first.VisualObservationsInserted != 2 {
+		t.Fatalf("first leo import = %#v", first)
+	}
+	if first.CategoriesSeen["1500"] != 1 || first.CategoriesSeen["1201"] != 1 {
+		t.Fatalf("leo categories = %#v", first.CategoriesSeen)
+	}
+	if second.GroupsRead != first.GroupsRead || second.VisualObservationsInserted != first.VisualObservationsInserted {
+		t.Fatalf("second leo import = %#v, first %#v", second, first)
+	}
+
+	search, err := Search(ctx, paths, SearchOptions{Query: "ceramics", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(search.Results) != 1 || search.Results[0].Source != photosSearchIndexSource || search.Results[0].ObservationType != "apple_label" {
+		t.Fatalf("leo search = %#v", search.Results)
+	}
+}
+
+func createTestPhotosDB(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	execTestSQL(t, db, `create table ZPERSON (Z_PK integer primary key, ZDISPLAYNAME text, ZFULLNAME text, ZPERSONUUID text)`)
+	execTestSQL(t, db, `create table ZDETECTEDFACE (Z_PK integer primary key, ZUUID text, ZPERSONFORFACE integer, ZASSETFORFACE integer, ZCENTERX real, ZCENTERY real, ZSIZE real, ZQUALITY real, ZNAMESOURCE integer, ZCLOUDNAMESOURCE integer, ZSOURCEWIDTH integer, ZSOURCEHEIGHT integer)`)
+	execTestSQL(t, db, `create table ZASSET (Z_PK integer primary key, ZUUID text)`)
+	execTestSQL(t, db, `insert into ZPERSON(Z_PK, ZDISPLAYNAME, ZFULLNAME, ZPERSONUUID) values (1, 'Alex', 'Alex', '08EA22FD-06A7-4145-829F-D724B9DD1BB6')`)
+	execTestSQL(t, db, `insert into ZASSET(Z_PK, ZUUID) values (1, '92D69D06-27F0-4831-AEC7-C6F640F075BA')`)
+	execTestSQL(t, db, `insert into ZDETECTEDFACE(Z_PK, ZUUID, ZPERSONFORFACE, ZASSETFORFACE, ZCENTERX, ZCENTERY, ZSIZE, ZQUALITY, ZNAMESOURCE, ZCLOUDNAMESOURCE, ZSOURCEWIDTH, ZSOURCEHEIGHT) values (1, 'face-1', 1, 1, 0.5, 0.5, 0.2, 0.9, 1, 0, 100, 100)`)
+}
+
+func createTestPSIDB(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	execTestSQL(t, db, `create table assets (uuid_0 integer, uuid_1 integer)`)
+	execTestSQL(t, db, `create table groups (category integer, owning_groupid integer, content_string text, normalized_string text, lookup_identifier text, score real)`)
+	execTestSQL(t, db, `create table ga (assetid integer, groupid integer)`)
+	execTestSQL(t, db, `insert into assets(rowid, uuid_0, uuid_1) values (1, 3551352356587034258, -5010834848571013202)`)
+	execTestSQL(t, db, `insert into groups(rowid, category, owning_groupid, content_string, normalized_string, lookup_identifier, score) values (10, 1500, null, 'Antique Car'||char(0), 'antique car'||char(0), '', 0.9)`)
+	execTestSQL(t, db, `insert into groups(rowid, category, owning_groupid, content_string, normalized_string, lookup_identifier, score) values (11, 1300, null, 'Alex'||char(0), 'alex'||char(0), '08EA22FD-06A7-4145-829F-D724B9DD1BB6'||char(0), 0.8)`)
+	execTestSQL(t, db, `insert into groups(rowid, category, owning_groupid, content_string, normalized_string, lookup_identifier, score) values (12, 9999, null, 'Future Thing', 'future thing', '', 0.7)`)
+	execTestSQL(t, db, `insert into ga(rowid, assetid, groupid) values (100, 1, 10), (101, 1, 11), (102, 1, 12)`)
+}
+
+func createTestLeoDB(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	execTestSQL(t, db, `create table lexicon (lexeme_id integer primary key, type integer, category integer, content text)`)
+	execTestSQL(t, db, `create table items (identifier text, type integer, lexeme_ids blob)`)
+	execTestSQL(t, db, `insert into lexicon(lexeme_id, type, category, content) values (1, 1, 4000, 'Ceramics'), (2, 1, 7000, 'Studio Archive'), (3, 1, 9999, 'Unsupported'), (4, 2, 4000, 'Ignored')`)
+	execTestSQL(t, db, `insert into items(rowid, identifier, type, lexeme_ids) values (1, ?, 1, ?)`, "92D69D06-27F0-4831-AEC7-C6F640F075BA", []byte{1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0})
+}
+
+func execTestSQL(t *testing.T, db *sql.DB, query string, args ...any) {
+	t.Helper()
+	if _, err := db.Exec(query, args...); err != nil {
+		t.Fatalf("exec %q: %v", query, err)
+	}
+}
+
+func assertCount(t *testing.T, db *sql.DB, query string, want int, args ...any) {
+	t.Helper()
+	var got int
+	if err := db.QueryRow(query, args...).Scan(&got); err != nil {
+		t.Fatalf("count %q: %v", query, err)
+	}
+	if got != want {
+		t.Fatalf("count %q = %d, want %d", query, got, want)
+	}
+}

--- a/internal/archive/migrations.go
+++ b/internal/archive/migrations.go
@@ -126,6 +126,7 @@ func migrateArchiveSchema(ctx context.Context, db *store.Store) error {
 			{"asset_resource", "deletion_source", "text"},
 			{"asset_resource", "deletion_reason", "text"},
 			{"asset_resource", "source_identifier", "text"},
+			{"album_membership", "folder_path", "text not null default ''"},
 		}
 		for _, column := range columns {
 			if err := ensureArchiveColumn(ctx, tx, column.table, column.name, column.definition); err != nil {

--- a/internal/archive/migrations_test.go
+++ b/internal/archive/migrations_test.go
@@ -40,7 +40,7 @@ create table asset_resource (
 );
 `
 
-func TestSchemaV2MigrationPreservesV1AssetRows(t *testing.T) {
+func TestSchemaMigrationPreservesV1AssetRows(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "photos.sqlite")
@@ -114,6 +114,41 @@ insert into asset_resource values ('resource-1', 'asset-1', 'thumbnail', 'public
 	}
 	if assetDeleted != nil || resourceDeleted != nil {
 		t.Fatalf("migration invented tombstones: asset=%v resource=%v", assetDeleted, resourceDeleted)
+	}
+}
+
+func TestSchemaV3MigrationAddsAlbumFolderPath(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "photos.sqlite")
+	schemaV2 := strings.Replace(Schema, ",\n  folder_path text not null default ''", "", 1)
+	legacy, err := store.Open(ctx, store.Options{Path: dbPath, Schema: schemaV2, SchemaVersion: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.DB().ExecContext(ctx, `
+insert into source_library values ('library-1', '/fixture', 'snapshot', '2026-07-18T00:00:00Z', 'fixture', '{}');
+insert into asset values ('asset-1', 'local-1', 'image', '', '2026-07-18T00:00:00Z', '2026-07-18T00:00:00Z', '', '', 10, 20, 0, 0, 0, '', 0, 'library-1', '{"kept":true}', null, null, null);
+insert into album_membership(id, asset_id, album_id, album_title, album_kind) values ('membership-1', 'asset-1', 'album-1', 'Trip', 'album:1:2');
+`); err != nil {
+		legacy.Close()
+		t.Fatal(err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := openArchiveStore(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer migrated.Close()
+	var folderPath string
+	if err := migrated.DB().QueryRowContext(ctx, `select folder_path from album_membership where id = 'membership-1'`).Scan(&folderPath); err != nil {
+		t.Fatal(err)
+	}
+	if folderPath != "" {
+		t.Fatalf("migrated folder_path = %q", folderPath)
 	}
 }
 

--- a/internal/archive/query.go
+++ b/internal/archive/query.go
@@ -20,13 +20,15 @@ type SearchResult struct {
 }
 
 type SearchHit struct {
-	ID            string `json:"id"`
-	HitType       string `json:"hit_type"`
-	ObservationID string `json:"observation_id,omitempty"`
-	MediaType     string `json:"media_type"`
-	CreationDate  string `json:"creation_date"`
-	Title         string `json:"title"`
-	Snippet       string `json:"snippet"`
+	ID              string `json:"id"`
+	HitType         string `json:"hit_type"`
+	ObservationID   string `json:"observation_id,omitempty"`
+	Source          string `json:"source,omitempty"`
+	ObservationType string `json:"observation_type,omitempty"`
+	MediaType       string `json:"media_type"`
+	CreationDate    string `json:"creation_date"`
+	Title           string `json:"title"`
+	Snippet         string `json:"snippet"`
 }
 
 type OpenResult struct {
@@ -97,10 +99,21 @@ limit ?
 	if len(result.Results) < limit {
 		observationLimit := limit - len(result.Results)
 		observationRows, err := db.DB().QueryContext(ctx, `
-select asset.id, observation_fts.id, asset.media_type, asset.creation_date, observation_fts.title,
+select asset.id, observation_fts.id,
+       coalesce(visual_observation.source, face_observation.source, text_observation.source, model_observation.source, '') as source,
+       coalesce(visual_observation.observation_type,
+                case when face_observation.id is not null then 'face' end,
+                case when text_observation.id is not null then 'text' end,
+                model_observation.observation_type,
+                '') as observation_type,
+       asset.media_type, asset.creation_date, observation_fts.title,
        snippet(observation_fts, 3, '[', ']', ' ... ', 12) as snippet
 from observation_fts
 join asset on asset.id = observation_fts.asset_id
+left join visual_observation on visual_observation.id = observation_fts.id
+left join face_observation on face_observation.id = observation_fts.id
+left join text_observation on text_observation.id = observation_fts.id
+left join model_observation on model_observation.id = observation_fts.id
 where observation_fts match ? and asset.deleted_at is null
 order by rank
 limit ?
@@ -111,7 +124,7 @@ limit ?
 		defer observationRows.Close()
 		for observationRows.Next() {
 			var hit SearchHit
-			if err := observationRows.Scan(&hit.ID, &hit.ObservationID, &hit.MediaType, &hit.CreationDate, &hit.Title, &hit.Snippet); err != nil {
+			if err := observationRows.Scan(&hit.ID, &hit.ObservationID, &hit.Source, &hit.ObservationType, &hit.MediaType, &hit.CreationDate, &hit.Title, &hit.Snippet); err != nil {
 				return SearchResult{}, err
 			}
 			hit.HitType = "observation"
@@ -159,10 +172,10 @@ order by resource_type, original_filename
 		return OpenResult{}, err
 	}
 	albums, err := rows(ctx, db.DB(), `
-select id, album_id, album_title, album_kind
+select id, album_id, album_title, album_kind, folder_path
 from album_membership
 where asset_id = ?
-order by album_title, album_id
+order by folder_path, album_title, album_id
 `, rowID)
 	if err != nil {
 		return OpenResult{}, err

--- a/internal/archive/schema.go
+++ b/internal/archive/schema.go
@@ -1,6 +1,6 @@
 package archive
 
-const SchemaVersion = 2
+const SchemaVersion = 3
 
 const Schema = `
 create table if not exists source_library (
@@ -99,7 +99,8 @@ create table if not exists album_membership (
   asset_id text not null references asset(id),
   album_id text not null,
   album_title text not null,
-  album_kind text not null
+  album_kind text not null,
+  folder_path text not null default ''
 );
 
 create table if not exists location_observation (

--- a/internal/archive/timeline.go
+++ b/internal/archive/timeline.go
@@ -42,9 +42,10 @@ type TimelineObservation struct {
 }
 
 type TimelineAlbum struct {
-	ID    string `json:"id"`
-	Title string `json:"title"`
-	Kind  string `json:"kind"`
+	ID         string `json:"id"`
+	Title      string `json:"title"`
+	Kind       string `json:"kind"`
+	FolderPath string `json:"folder_path,omitempty"`
 }
 
 func Timeline(ctx context.Context, paths Paths, opts TimelineOptions) (TimelineResult, error) {
@@ -76,7 +77,7 @@ func Timeline(ctx context.Context, paths Paths, opts TimelineOptions) (TimelineR
 select asset.id, location_observation.id, asset.creation_date, asset.media_type,
        coalesce(cast(json_extract(asset.metadata_json, '$.source_type') as integer), 0),
        coalesce((
-         select json_group_array(json_object('id', album_id, 'title', album_title, 'kind', album_kind))
+         select json_group_array(json_object('id', album_id, 'title', album_title, 'kind', album_kind, 'folder_path', folder_path))
          from album_membership
          where album_membership.asset_id = asset.id
        ), '[]'),

--- a/internal/archive/timeline_test.go
+++ b/internal/archive/timeline_test.go
@@ -28,7 +28,7 @@ func TestTimelineReturnsLocatedAssetsInHalfOpenRange(t *testing.T) {
 				Height:           3024,
 				Metadata:         map[string]any{"source_type": 2},
 				Albums: []photos.AlbumMembership{
-					{AlbumID: "shared-trip", AlbumTitle: "Trip", AlbumKind: "album:1:101"},
+					{AlbumID: "shared-trip", AlbumTitle: "Trip", AlbumKind: "album:1:101", FolderPath: "Travel / 2026"},
 				},
 				Location: &photos.Location{
 					Latitude:           52.3676,
@@ -76,7 +76,7 @@ func TestTimelineReturnsLocatedAssetsInHalfOpenRange(t *testing.T) {
 	if observation.CreatedAt != "2026-05-27T10:00:00Z" || observation.MediaType != "image" {
 		t.Fatalf("asset metadata = %#v", observation)
 	}
-	if observation.SourceType != 2 || len(observation.Albums) != 1 || observation.Albums[0].Title != "Trip" {
+	if observation.SourceType != 2 || len(observation.Albums) != 1 || observation.Albums[0].Title != "Trip" || observation.Albums[0].FolderPath != "Travel / 2026" {
 		t.Fatalf("source metadata = %#v", observation)
 	}
 	if observation.Latitude == nil || observation.Longitude == nil || observation.AccuracyMeters == nil || *observation.AccuracyMeters != accuracy || observation.IsPrecise == nil || !*observation.IsPrecise {

--- a/internal/photos/photokit_bridge_darwin.m
+++ b/internal/photos/photokit_bridge_darwin.m
@@ -240,11 +240,47 @@ static PHAssetResource *pcPreferredOriginalResource(PHAsset *asset) {
   return bestRank < 100 ? best : nil;
 }
 
-static NSDictionary *pcAlbumDictionary(PHAssetCollection *collection) {
+static void pcIndexCollectionPaths(PHFetchResult<PHCollection *> *collections,
+                                   NSArray<NSString *> *parentTitles,
+                                   NSMutableDictionary *folderPaths,
+                                   NSMutableSet *visitedLists) {
+  [collections enumerateObjectsUsingBlock:^(PHCollection *collection, NSUInteger idx, BOOL *stop) {
+    if ([collection isKindOfClass:[PHCollectionList class]]) {
+      PHCollectionList *list = (PHCollectionList *)collection;
+      NSString *listID = pcString(list.localIdentifier);
+      if ([visitedLists containsObject:listID]) {
+        return;
+      }
+      [visitedLists addObject:listID];
+      NSMutableArray<NSString *> *childTitles = [NSMutableArray arrayWithArray:parentTitles];
+      if (list.localizedTitle.length > 0) {
+        [childTitles addObject:list.localizedTitle];
+      }
+      PHFetchResult<PHCollection *> *children = [PHCollection fetchCollectionsInCollectionList:list options:nil];
+      pcIndexCollectionPaths(children, childTitles, folderPaths, visitedLists);
+      return;
+    }
+    if ([collection isKindOfClass:[PHAssetCollection class]]) {
+      NSString *collectionID = pcString(collection.localIdentifier);
+      folderPaths[collectionID] = [parentTitles componentsJoinedByString:@" / "];
+    }
+  }];
+}
+
+static NSDictionary *pcCollectionFolderPaths(void) {
+  NSMutableDictionary *out = [NSMutableDictionary dictionary];
+  NSMutableSet *visitedLists = [NSMutableSet set];
+  PHFetchResult<PHCollection *> *topLevel = [PHCollectionList fetchTopLevelUserCollectionsWithOptions:nil];
+  pcIndexCollectionPaths(topLevel, @[], out, visitedLists);
+  return out;
+}
+
+static NSDictionary *pcAlbumDictionary(PHAssetCollection *collection, NSDictionary *folderPaths) {
   return @{
     @"album_id": pcString(collection.localIdentifier),
     @"album_title": pcString(collection.localizedTitle),
-    @"album_kind": [NSString stringWithFormat:@"album:%ld:%ld", (long)collection.assetCollectionType, (long)collection.assetCollectionSubtype]
+    @"album_kind": [NSString stringWithFormat:@"album:%ld:%ld", (long)collection.assetCollectionType, (long)collection.assetCollectionSubtype],
+    @"folder_path": pcString(folderPaths[pcString(collection.localIdentifier)])
   };
 }
 
@@ -257,38 +293,50 @@ static void pcAddAlbum(NSMutableArray *albums, NSMutableSet *albumIDs, NSDiction
   [albums addObject:album];
 }
 
-static NSDictionary *pcSharedAlbumsByAssetID(void) {
-  NSMutableDictionary *out = [NSMutableDictionary dictionary];
-  PHFetchResult<PHAssetCollection *> *collections = [PHAssetCollection
-      fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
-      subtype:PHAssetCollectionSubtypeAlbumCloudShared
-      options:nil];
+static void pcIndexCollectionMemberships(PHFetchResult<PHAssetCollection *> *collections,
+                                         NSDictionary *folderPaths,
+                                         NSMutableDictionary *membershipsByAssetID) {
   [collections enumerateObjectsUsingBlock:^(PHAssetCollection *collection, NSUInteger idx, BOOL *stop) {
-    NSDictionary *album = pcAlbumDictionary(collection);
+    NSDictionary *album = pcAlbumDictionary(collection, folderPaths);
     PHFetchOptions *assetOptions = [[PHFetchOptions alloc] init];
-    assetOptions.includeAssetSourceTypes = PHAssetSourceTypeUserLibrary | PHAssetSourceTypeCloudShared;
+    assetOptions.includeAssetSourceTypes = PHAssetSourceTypeUserLibrary |
+        PHAssetSourceTypeCloudShared | PHAssetSourceTypeiTunesSynced;
     PHFetchResult<PHAsset *> *assets = [PHAsset fetchAssetsInAssetCollection:collection options:assetOptions];
     [assets enumerateObjectsUsingBlock:^(PHAsset *asset, NSUInteger assetIdx, BOOL *assetStop) {
       NSString *assetID = pcString(asset.localIdentifier);
-      NSMutableArray *memberships = out[assetID];
+      NSMutableArray *memberships = membershipsByAssetID[assetID];
       if (memberships == nil) {
         memberships = [NSMutableArray array];
-        out[assetID] = memberships;
+        membershipsByAssetID[assetID] = memberships;
       }
       [memberships addObject:album];
     }];
   }];
+}
+
+static NSDictionary *pcSupplementalAlbumsByAssetID(NSDictionary *folderPaths) {
+  NSMutableDictionary *out = [NSMutableDictionary dictionary];
+  PHFetchResult<PHAssetCollection *> *sharedCollections = [PHAssetCollection
+      fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
+      subtype:PHAssetCollectionSubtypeAlbumCloudShared
+      options:nil];
+  pcIndexCollectionMemberships(sharedCollections, folderPaths, out);
+  PHFetchResult<PHAssetCollection *> *smartCollections = [PHAssetCollection
+      fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum
+      subtype:PHAssetCollectionSubtypeAny
+      options:nil];
+  pcIndexCollectionMemberships(smartCollections, folderPaths, out);
   return out;
 }
 
-static NSArray *pcAlbums(PHAsset *asset, NSArray *knownSharedAlbums) {
+static NSArray *pcAlbums(PHAsset *asset, NSArray *knownSupplementalAlbums, NSDictionary *folderPaths) {
   NSMutableArray *out = [NSMutableArray array];
   NSMutableSet *albumIDs = [NSMutableSet set];
   PHFetchResult<PHAssetCollection *> *collections = [PHAssetCollection fetchAssetCollectionsContainingAsset:asset withType:PHAssetCollectionTypeAlbum options:nil];
   [collections enumerateObjectsUsingBlock:^(PHAssetCollection *collection, NSUInteger idx, BOOL *stop) {
-    pcAddAlbum(out, albumIDs, pcAlbumDictionary(collection));
+    pcAddAlbum(out, albumIDs, pcAlbumDictionary(collection, folderPaths));
   }];
-  for (NSDictionary *album in knownSharedAlbums) {
+  for (NSDictionary *album in knownSupplementalAlbums) {
     pcAddAlbum(out, albumIDs, album);
   }
   [out sortUsingComparator:^NSComparisonResult(NSDictionary *left, NSDictionary *right) {
@@ -297,7 +345,7 @@ static NSArray *pcAlbums(PHAsset *asset, NSArray *knownSharedAlbums) {
   return out;
 }
 
-static NSDictionary *pcAssetDictionary(PHAsset *asset, NSArray *knownSharedAlbums) {
+static NSDictionary *pcAssetDictionary(PHAsset *asset, NSArray *knownSupplementalAlbums, NSDictionary *folderPaths) {
   NSMutableDictionary *entry = [NSMutableDictionary dictionary];
   entry[@"local_identifier"] = pcString(asset.localIdentifier);
   entry[@"media_type"] = pcMediaType(asset.mediaType);
@@ -323,7 +371,7 @@ static NSDictionary *pcAssetDictionary(PHAsset *asset, NSArray *knownSharedAlbum
     entry[@"location"] = location;
   }
   entry[@"resources"] = pcResources(asset);
-  entry[@"albums"] = pcAlbums(asset, knownSharedAlbums);
+  entry[@"albums"] = pcAlbums(asset, knownSupplementalAlbums, folderPaths);
   entry[@"metadata"] = @{
     @"photokit_local_identifier": pcString(asset.localIdentifier),
     @"source_type": @((long long)asset.sourceType)
@@ -368,11 +416,12 @@ char *photoscrawl_photokit_snapshot(const char *libraryPath, char **errorOut) {
       ];
 
       PHFetchResult<PHAsset *> *fetch = [PHAsset fetchAssetsWithOptions:options];
-      NSDictionary *sharedAlbumsByAssetID = pcSharedAlbumsByAssetID();
+      NSDictionary *folderPaths = pcCollectionFolderPaths();
+      NSDictionary *supplementalAlbumsByAssetID = pcSupplementalAlbumsByAssetID(folderPaths);
       NSMutableArray *assets = [NSMutableArray arrayWithCapacity:fetch.count];
       [fetch enumerateObjectsUsingBlock:^(PHAsset *asset, NSUInteger idx, BOOL *stop) {
-        NSArray *sharedAlbums = sharedAlbumsByAssetID[pcString(asset.localIdentifier)];
-        [assets addObject:pcAssetDictionary(asset, sharedAlbums == nil ? @[] : sharedAlbums)];
+        NSArray *supplementalAlbums = supplementalAlbumsByAssetID[pcString(asset.localIdentifier)];
+        [assets addObject:pcAssetDictionary(asset, supplementalAlbums == nil ? @[] : supplementalAlbums, folderPaths)];
       }];
       [assets sortUsingComparator:^NSComparisonResult(NSDictionary *left, NSDictionary *right) {
         return [pcString(left[@"local_identifier"]) compare:pcString(right[@"local_identifier"])];
@@ -458,16 +507,19 @@ int photoscrawl_export_original_resource(const char *localIdentifier, const char
     PHAssetResourceRequestOptions *options = [[PHAssetResourceRequestOptions alloc] init];
     options.networkAccessAllowed = allowNetwork ? YES : NO;
 
-    __block NSError *writeError = nil;
+    __block NSString *writeErrorDescription = nil;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     [[PHAssetResourceManager defaultManager] writeDataForAssetResource:resource toFile:destination options:options completionHandler:^(NSError * _Nullable error) {
-      writeError = error;
+      if (error != nil) {
+        writeErrorDescription = [error.localizedDescription copy];
+      }
       dispatch_semaphore_signal(semaphore);
     }];
     dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
 
-    if (writeError != nil) {
-      pcSetError(errorOut, [NSString stringWithFormat:@"export original resource: %@", writeError.localizedDescription]);
+    if (writeErrorDescription != nil) {
+      pcSetError(errorOut, [NSString stringWithFormat:@"export original resource: %@", writeErrorDescription]);
+      [writeErrorDescription release];
       return 0;
     }
     return 1;

--- a/internal/photos/types.go
+++ b/internal/photos/types.go
@@ -57,6 +57,7 @@ type AlbumMembership struct {
 	AlbumID    string `json:"album_id"`
 	AlbumTitle string `json:"album_title"`
 	AlbumKind  string `json:"album_kind"`
+	FolderPath string `json:"folder_path,omitempty"`
 }
 
 type Location struct {


### PR DESCRIPTION
## Summary

- add a read-only Apple metadata import for named people and Photos search labels
- support both psi.sqlite and leo.sqlite search indexes
- preserve regular, shared, and smart album membership with folder paths
- expose imported observation sources in search and status output
- make live SQLite copies retry until database and WAL hashes match, then run SQLite quick-check before import
- preflight both Apple databases and commit people plus labels in one all-or-nothing archive transaction
- document the one-time archive upgrade and macOS Full Disk Access recovery

## Testing

- `make check`
- concurrent WAL regression verifies SQLite integrity and zero partial transactions
- atomic failure regression leaves existing people and search observations unchanged
- combined PSI import test verifies the atomic refresh and unique asset count; Leo is covered by a synthetic private-schema fixture

## Real-library proof

A signed background worker completed the after-fix import against an authorized real Apple Photos library:

- 24,754 named-face records imported across 16,607 assets
- 1,307,274 PSI search rows resolved and imported across 43,386 assets
- 43,391 unique assets touched by the atomic refresh
- zero process errors and atomic sync strategy reported
- a redacted search smoke check returned five results including `photos_search_index` / `apple_text` observations
