### PR TITLE
fix(evalcard): return manifest flush and close errors

### DIFF
--- a/internal/evalcard/evalcard.go
+++ b/internal/evalcard/evalcard.go
@@ -196,7 +196,6 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 	}
 	defer manifest.Close()
 	writer := bufio.NewWriter(manifest)
-	defer writer.Flush()
 
 	inputs := []preparedInput{}
 	for _, asset := range assets {
@@ -225,6 +224,10 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 		result.ModelCallsAttempted = len(inputs) * len(opts.Models)
 		result.ModelCallsSucceeded = succeeded
 		result.ModelCallsFailed = failed
+	}
+
+	if err := commitManifest(writer, manifest); err != nil {
+		return Result{}, err
 	}
 
 	summary, err := json.MarshalIndent(result, "", "  ")
@@ -374,4 +377,13 @@ func classifySkip(err error) string {
 		return "unknown"
 	}
 	return value
+}
+
+var commitManifest = finishManifest
+
+func finishManifest(w *bufio.Writer, f *os.File) error {
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	return f.Close()
 }

--- a/internal/evalcard/evalcard_test.go
+++ b/internal/evalcard/evalcard_test.go
@@ -1,10 +1,16 @@
 package evalcard
 
 import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/openclaw/photoscrawl/internal/photos"
 )
 
 func TestNormalizeOllamaGenerateURL(t *testing.T) {
@@ -65,4 +71,103 @@ func TestPromptWithMetadataUsesTemplateFileText(t *testing.T) {
 	if got != "Prompt\n\n{\"asset\":\"A\"}" {
 		t.Fatalf("promptWithMetadata = %q", got)
 	}
+}
+
+func TestFinishManifestReturnsFlushError(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.Create(filepath.Join(dir, "manifest.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	want := errors.New("no space left on device")
+	writer := bufio.NewWriterSize(errWriter{err: want}, 64)
+	if _, err := writer.WriteString(`{"eval_id":"E001"}` + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	err = finishManifest(writer, f)
+	if !errors.Is(err, want) {
+		t.Fatalf("finishManifest = %v, want %v", err, want)
+	}
+}
+
+func TestFinishManifestReturnsCloseError(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.Create(filepath.Join(dir, "manifest.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	err = finishManifest(bufio.NewWriter(io.Discard), f)
+	if err == nil {
+		t.Fatal("finishManifest succeeded on an already-closed file")
+	}
+}
+
+func TestRunReturnsManifestFlushErrorBeforeWritingSummary(t *testing.T) {
+	orig := commitManifest
+	want := errors.New("no space left on device")
+	commitManifest = func(*bufio.Writer, *os.File) error {
+		return want
+	}
+	t.Cleanup(func() { commitManifest = orig })
+
+	opts, summaryPath := evalRunOptions(t)
+	_, err := Run(context.Background(), opts)
+	if !errors.Is(err, want) {
+		t.Fatalf("Run = %v, want %v", err, want)
+	}
+	if _, statErr := os.Stat(summaryPath); !os.IsNotExist(statErr) {
+		t.Fatalf("summary.json exists after manifest flush failure: %v", statErr)
+	}
+}
+
+func TestRunWritesSummaryAfterManifestCommit(t *testing.T) {
+	opts, summaryPath := evalRunOptions(t)
+	result, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(result.ManifestPath); err != nil {
+		t.Fatalf("manifest.jsonl: %v", err)
+	}
+	if _, err := os.Stat(summaryPath); err != nil {
+		t.Fatalf("summary.json: %v", err)
+	}
+}
+
+func evalRunOptions(t *testing.T) (Options, string) {
+	t.Helper()
+	dir := t.TempDir()
+	lib := filepath.Join(dir, "lib")
+	if err := os.Mkdir(lib, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prompt := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(prompt, []byte("prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "out")
+	return Options{
+		LibraryPath: lib,
+		OutputDir:   out,
+		CacheDir:    filepath.Join(dir, "cache"),
+		PromptPath:  prompt,
+		Provider:    stubProvider{},
+		Limit:       1,
+	}, filepath.Join(out, "summary.json")
+}
+
+type stubProvider struct{}
+
+func (stubProvider) Snapshot(context.Context, string) (photos.LibrarySnapshot, error) {
+	return photos.LibrarySnapshot{}, nil
+}
+
+type errWriter struct{ err error }
+
+func (w errWriter) Write([]byte) (int, error) {
+	return 0, w.err
 }


### PR DESCRIPTION
## What Problem This Solves

`photoscrawl eval-card` writes `manifest.jsonl` through a `bufio.Writer` and then writes `summary.json` with `AssetsPrepared`. Flush and Close ran only as defers after that summary write, and their errors were discarded. A failed flush (disk full) can leave `summary.json` claiming rows that never landed in `manifest.jsonl`.

The harness now flushes and closes the manifest on the success path and returns those errors before writing `summary.json`.

## Evidence

Live `go run` of the old vs new flush order. The old path writes `summary.json` first and discards the flush error. The new path returns `no space left on device` and never writes the summary.

```console
$ go run /tmp/f004-repro.go
OLD summary_exists=true flush_err=discarded assets_prepared=1
NEW summary_exists=false err="no space left on device"
```

`node` inspect of `Run` on `upstream/main` vs this branch:

```console
$ node /tmp/inspect-f004.js
node inspect eval-card Run (upstream/main)
has_defer_flush=true
has_defer_close=true
commit_before_summary=false
returns_commit_err=false
result=UNFIXED

node inspect eval-card Run
has_defer_flush=false
has_defer_close=true
commit_before_summary=true
returns_commit_err=true
result=PATCH_ACTIVE
```

Live `evalcard.Run` after the patch, synthetic provider, empty library, no Photos access. Manifest commit finishes, then `summary.json` is written.

```console
$ go run ./cmd/f004live
output_dir=/var/folders/7_/3g02szlx2h3_4pdqp0knlw740000gn/T/f004-live-2369260115/out
assets_prepared=0
summary_bytes=904
manifest_bytes=0
summary_path_exists=true
manifest_path_exists=true
```

Environment: Darwin 25.6.0 arm64, Go 1.27.0. This discard has been present since [a5c76e8](https://github.com/openclaw/photoscrawl/commit/a5c76e86) (2026-05-30), the original photo-card harness. Independent of [#9](https://github.com/openclaw/photoscrawl/pull/9), [#10](https://github.com/openclaw/photoscrawl/pull/10), and [#16](https://github.com/openclaw/photoscrawl/pull/16).

## Real behavior proof

- **Behavior or issue addressed:** `eval-card` returns manifest flush and close errors before writing `summary.json`, so `AssetsPrepared` cannot claim rows that never landed.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Go 1.27.0, worktree `/tmp/oc-pr-photoscrawl-F004` on branch `fix/f004-evalcard-flush-close`. Synthetic provider. No live Photos library.
- **Exact steps or command run after this patch:** Compared `go run /tmp/f004-repro.go` old vs new flush order. Inspected `internal/evalcard/evalcard.go` with `node`. Ran `evalcard.Run` from a temporary in-tree command against a temp output dir.
- **Evidence after fix:** terminal output above. Old path: `summary_exists=true`, `flush_err=discarded`. New path: `summary_exists=false`, `err="no space left on device"`. Node reported `commit_before_summary=true` and `result=PATCH_ACTIVE`. Live `evalcard.Run` wrote `summary.json` only after the manifest commit (`summary_path_exists=true`, `assets_prepared=0`).
- **Observed result after fix:** A manifest flush failure stops the run before `summary.json` exists. A successful commit still writes both `manifest.jsonl` and `summary.json`.
- **What was not tested:** A real disk-full ENOSPC on a Photos library eval with prepared JPEGs. The injected flush error is the same return the writer surfaces when the underlying write fails.

## Summary

`Run` calls `commitManifest` (flush, then close) after writing rows and before `summary.json`. Early returns still rely on `defer manifest.Close()` for cleanup. Sampling, model calls, and prompt hashing are unchanged.
