### PR TITLE
chore(deps): refresh CrawlKit and Go toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Require macOS 13 Ventura or later with the update to Go 1.27.0 and CrawlKit v0.14.8.
 - Update to Go 1.26.7, CrawlKit v0.14.7, SQLite v1.57.0, deadcode v0.49.0, and the v7 checkout/setup-go actions; retain CodeQL's supported Go toolchain.
 - Update Go dependencies, including `go-isatty` v0.0.24 and `x/sys` v0.47.0.
 - Standardize the Makefile's build, check, snapshot, and fail-closed release targets across the crawler repositories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-- Require macOS 13 Ventura or later with the update to Go 1.27.0 and CrawlKit v0.14.8.
 - Update to Go 1.26.7, CrawlKit v0.14.7, SQLite v1.57.0, deadcode v0.49.0, and the v7 checkout/setup-go actions; retain CodeQL's supported Go toolchain.
 - Update Go dependencies, including `go-isatty` v0.0.24 and `x/sys` v0.47.0.
+- Require macOS 13 Ventura or later with the update to Go 1.27.0 and CrawlKit v0.14.8.
 - Standardize the Makefile's build, check, snapshot, and fail-closed release targets across the crawler repositories.
 
 ## 0.1.0 - 2026-07-18

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ evidence supports each result.
 
 ## Installation
 
-The first release supports macOS on Apple silicon and Intel. `photoscrawl` uses
+Current builds require macOS 13 Ventura or later on Apple silicon or Intel. `photoscrawl` uses
 native Objective-C/CGO bridges to PhotoKit, CoreLocation, MapKit, CoreImage,
 CoreGraphics, and ImageIO, so v0.1.x release archives are intentionally
 Darwin-only. Download the archive for your architecture from GitHub Releases,
@@ -34,6 +34,8 @@ photoscrawl --version
 There is no Homebrew formula in the debut release.
 
 ## Development
+
+Building from source requires Go 1.27.0 or later and the macOS SDK.
 
 The Makefile exposes the same core targets as the other OpenClaw crawler
 repositories:

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/openclaw/photoscrawl
 
-go 1.26.7
+go 1.27.0
 
 require (
-	github.com/openclaw/crawlkit v0.14.7
+	github.com/openclaw/crawlkit v0.14.8
 	modernc.org/sqlite v1.57.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsRe
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.7 h1:Kvceob5WyEtrGt4YkwKRcepU77g7FX/HPTRIiCe+ArQ=
-github.com/openclaw/crawlkit v0.14.7/go.mod h1:iDnctBAFtqB5l2sHREfpyjQwifToeebDVdVJvZWVLn0=
+github.com/openclaw/crawlkit v0.14.8 h1:JdmvIcfznzGGDNczACtktebd0ueLWaTrCwW8ZPtm7Fg=
+github.com/openclaw/crawlkit v0.14.8/go.mod h1:7QxbJgGm6ZQAiBXyWSR+U6Eyt8p4pMcC7zjY0h3GKjY=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/internal/evalcard/evalcard.go
+++ b/internal/evalcard/evalcard.go
@@ -272,17 +272,17 @@ func prepareInput(ctx context.Context, localMedia photos.LocalMediaIndex, output
 		return preparedInput{}, manifestRow{}, err
 	}
 	return preparedInput{
-			ID:           id,
-			ImagePath:    imagePath,
-			MetadataPath: metadataPath,
-			MetadataJSON: metadataJSON,
-		}, manifestRow{
-			EvalID:       id,
-			ImagePath:    imagePath,
-			MetadataPath: metadataPath,
-			OriginalPath: originalPath,
-			OriginalMode: source,
-		}, nil
+		ID:           id,
+		ImagePath:    imagePath,
+		MetadataPath: metadataPath,
+		MetadataJSON: metadataJSON,
+	}, manifestRow{
+		EvalID:       id,
+		ImagePath:    imagePath,
+		MetadataPath: metadataPath,
+		OriginalPath: originalPath,
+		OriginalMode: source,
+	}, nil
 }
 
 func resolveOriginal(ctx context.Context, localMedia photos.LocalMediaIndex, cacheDir string, asset photos.Asset, allowICloud bool) (string, string, error) {


### PR DESCRIPTION
Refresh CrawlKit from v0.14.7 to v0.14.8 and its required Go toolchain from 1.26.7 to 1.27.0. Regenerate module checksums with Go, document the resulting macOS 13 minimum, and apply gofmt to the two return literals in `internal/evalcard/evalcard.go` so the full local gate passes.

## Dependency audit

- Updated with `GOWORK=off go get -u ./...` and `GOWORK=off go mod tidy`. All directly declared and imported indirect modules are current; SQLite remains v1.57.0. No new dependencies were added.
- No direct-module major upgrade was needed. Reviewed [CrawlKit v0.14.8 notes](https://github.com/openclaw/crawlkit/releases/tag/v0.14.8) and [Go 1.27 release notes](https://go.dev/doc/go1.27); Go 1.27 requires macOS 13 or later, now documented in README and changelog.
- Action references are current: checkout `v7` resolves to v7.0.1, setup-go is v7.0.0, create-github-app-token is pinned to v3.2.0, and release-workflows `v1` resolves to v1.7.5. No workflow dependency edits were necessary.
- **NEEDS-PETER:** `devenv.lock` is behind the upstream rolling input, but neither `nix` nor `devenv` is installed on this worker. Left the lockfile unchanged. Recommend regenerating it with `devenv update` and validating the development shell on a Nix-equipped worker; this task was constrained to the existing checkout.

## Local validation

`make build BINARY=bin/photoscrawl-deps-refresh-20260830 VERSION=deps-refresh-20260830` succeeded. `make check BINARY=bin/photoscrawl-deps-refresh-20260830` then passed module verification, tidy, formatting, vet, deadcode, the full test suite, build, and the version smoke check. The first check stopped on formatting; it passed after the formatting-only correction.

Real output excerpts:

```text
all modules verified
GOWORK=off go mod tidy -diff
GOWORK=off go vet ./...
GOWORK=off go test -count=1 ./...
ok  	github.com/openclaw/photoscrawl/cmd/photoscrawl	0.519s
ok  	github.com/openclaw/photoscrawl/internal/archive	25.279s
ok  	github.com/openclaw/photoscrawl/internal/evalcard	7.632s
ok  	github.com/openclaw/photoscrawl/internal/photos	5.604s
ok  	github.com/openclaw/photoscrawl/internal/place	2.171s
?   	github.com/openclaw/photoscrawl/prompts	[no test files]
```

```sh
bin/photoscrawl-deps-refresh-20260830 --version
```

```text
ci
```

The native linker emitted its duplicate `-lobjc` warning; builds and tests exited successfully. Codex autoreview completed `scoped-clean` for the final diff at its default P0 threshold.

## CI reasoning

The initial NORUNS observation was stale. Default-branch [CI](https://github.com/openclaw/photoscrawl/actions/runs/33371692824) and [CodeQL](https://github.com/openclaw/photoscrawl/actions/runs/33371691975) were already green at base commit `83cbd32`. The CI workflow builds and tests on macOS; CodeQL is GitHub's default code-scanning setup. ClawSweeper Dispatch is event-driven maintenance automation, and Release (unified) is manual publication; neither is the build/test gate. There are no scheduled workflows in this checkout. No assertions, tests, jobs, or production settings were weakened or removed.

## Live CLI proof

A full-library probe was stopped after several minutes to bound this maintenance run. The successful proof uses five real asset rows and their related resource/album metadata, copied in one read transaction from the local Photos database opened with `mode=ro` into a temporary library under `/tmp`. No originals were copied and no cloud provider was called. All source identifiers and private metadata stayed outside the checkout; only aggregate counts are shown here.

```sh
bin/photoscrawl-deps-refresh-20260830 crawl --provider sqlite --library "$proof_dir/sample.photoslibrary" --db "$proof_dir/sample-archive.sqlite" --json > "$proof_dir/sample-crawl.json" 2> "$proof_dir/sample-crawl.stderr"
jq '{provider,assets_seen,assets_new,resources_seen,album_memberships_seen,locations_seen,queued_for_classify}' "$proof_dir/sample-crawl.json"
```

```json
{
  "provider": "photos_sqlite_snapshot",
  "assets_seen": 5,
  "assets_new": 5,
  "resources_seen": 11,
  "album_memberships_seen": 0,
  "locations_seen": 0,
  "queued_for_classify": 5
}
```

```sh
bin/photoscrawl-deps-refresh-20260830 status --db "$proof_dir/sample-archive.sqlite" --json > "$proof_dir/status.json"
jq '{state,counts:[.counts[] | select(.id == "asset" or .id == "asset_resource" or .id == "evidence_ref")]}' "$proof_dir/status.json"
```

```json
{
  "state": "ready",
  "counts": [
    {"id": "asset", "label": "asset", "value": 5},
    {"id": "asset_resource", "label": "asset_resource", "value": 11},
    {"id": "evidence_ref", "label": "evidence_ref", "value": 16}
  ]
}
```

The changelog entry is positioned to combine cleanly with concurrent Unreleased entries on `main`, preserving the published branch history. The latest default-branch [CI run](https://github.com/openclaw/photoscrawl/actions/runs/33372557910) is also green at `c36332f`. PR CodeQL [passed](https://github.com/openclaw/photoscrawl/actions/runs/33373563384) on the dependency commit.

Final PR [macOS build/test CI](https://github.com/openclaw/photoscrawl/actions/runs/33373794013) passed on `3637ae0`. The checkout was returned clean to `main`, and the temporary Photos snapshot/archive and task binary were removed. This PR remains unmerged; the Nix/devenv lockfile refresh above is the remaining tooling follow-up.
