### PR TITLE
fix(place): register the place-context-raw backfill bridge command

### DIFF
--- a/cmd/photoscrawl/main.go
+++ b/cmd/photoscrawl/main.go
@@ -365,6 +365,23 @@ func run(ctx context.Context, args []string) error {
 			return err
 		}
 		return output.Write(os.Stdout, format, "place_context", result)
+	case place.RawContextCommand:
+		// This is the place-backfill subprocess bridge.
+		fs := flag.NewFlagSet(place.RawContextCommand, flag.ContinueOnError)
+		fs.SetOutput(os.Stderr)
+		inputPath := fs.String("input", "-", "JSON place input path, or stdin")
+		radius := fs.Float64("radius", 150, "nearby POI search radius in meters")
+		if err := fs.Parse(args[1:]); err != nil {
+			return output.UsageError{Err: err}
+		}
+		result, err := place.RunRaw(ctx, place.RawOptions{
+			InputPath:    *inputPath,
+			RadiusMeters: *radius,
+		})
+		if err != nil {
+			return err
+		}
+		return output.Write(os.Stdout, output.JSON, "place_context_raw", result)
 	case "place-card":
 		fs := flag.NewFlagSet("place-card", flag.ContinueOnError)
 		fs.SetOutput(os.Stderr)
@@ -456,7 +473,7 @@ func run(ctx context.Context, args []string) error {
 }
 
 func usage() error {
-	return output.UsageError{Err: errors.New("usage: photoscrawl [--version] <version|metadata|init|status|crawl|import-apple|classify|search|timeline|open|export|neighbors|evidence|place-context|place-card|place-backfill|eval-card>")}
+	return output.UsageError{Err: errors.New("usage: photoscrawl [--version] <version|metadata|init|status|crawl|import-apple|classify|search|timeline|open|export|neighbors|evidence|place-context|place-context-raw|place-card|place-backfill|eval-card>")}
 }
 
 func writeVersion(w io.Writer) error {

--- a/cmd/photoscrawl/main_test.go
+++ b/cmd/photoscrawl/main_test.go
@@ -5,16 +5,35 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/openclaw/crawlkit/output"
+	"github.com/openclaw/photoscrawl/internal/place"
 	_ "modernc.org/sqlite"
 )
+
+func TestPlaceContextRawDispatchParsesInput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "invalid.json")
+	if err := os.WriteFile(path, []byte("{invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := run(context.Background(), []string{place.RawContextCommand, "--input", path})
+	if output.IsUsage(err) {
+		t.Fatalf("raw context command returned a usage error: %v", err)
+	}
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) || !strings.HasPrefix(err.Error(), "read place input:") {
+		t.Fatalf("raw context error = %v, want an input JSON parse error", err)
+	}
+}
 
 func TestCommandContextSecondInterruptTerminates(t *testing.T) {
 	if os.Getenv("PHOTOSCRAWL_TEST_SIGNAL_CHILD") == "1" {

--- a/docs/evals/geocoding-context.md
+++ b/docs/evals/geocoding-context.md
@@ -29,6 +29,7 @@ For provider evaluation, run `place-backfill` instead of wrapping
 dedupes exact latitude/longitude/accuracy keys, retries Apple failures, and
 writes all manifests, attempts, outputs, and final errors outside the repo under
 the crawlkit data dir's `backfills/place-context-full/apple-ingest` subtree.
+It shells out to the internal `place-context-raw` command per coordinate key.
 
 Provider evidence includes:
 

--- a/internal/place/backfill.go
+++ b/internal/place/backfill.go
@@ -311,7 +311,7 @@ func rawAppleResultSubprocess(ctx context.Context, input Input) (Result, error) 
 	if err != nil {
 		return Result{}, err
 	}
-	cmd := exec.CommandContext(ctx, executable, "place-context-raw", "--input", "-")
+	cmd := exec.CommandContext(ctx, executable, RawContextCommand, "--input", "-", "--radius", fmt.Sprint(backfillRadiusMeters))
 	cmd.Stdin = bytes.NewReader(data)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/place/backfill_subprocess_test.go
+++ b/internal/place/backfill_subprocess_test.go
@@ -1,0 +1,150 @@
+package place
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMain(m *testing.M) {
+	if len(os.Args) > 1 && os.Args[1] == RawContextCommand && os.Getenv("PHOTOSCRAWL_TEST_PLACE_RAW_CHILD") == "1" {
+		if err := runRawContextTestChild(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func runRawContextTestChild() error {
+	fs := flag.NewFlagSet(RawContextCommand, flag.ContinueOnError)
+	inputPath := fs.String("input", "", "")
+	radius := fs.Float64("radius", 0, "")
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 || *inputPath != "-" || *radius != backfillRadiusMeters {
+		return fmt.Errorf("expected stdin input and explicit backfill radius, got %v", os.Args[2:])
+	}
+	var input Input
+	if err := json.NewDecoder(os.Stdin).Decode(&input); err != nil {
+		return err
+	}
+	return json.NewEncoder(os.Stdout).Encode(Result{
+		Input:        input,
+		Provider:     "synthetic",
+		RadiusMeters: *radius,
+		Address:      &Address{Formatted: "Synthetic address"},
+		POIStatus:    POIStatusNone,
+	})
+}
+
+func TestBackfillRawSubprocess(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "photos.sqlite")
+	outDir := filepath.Join(dir, "backfill")
+	if err := writeBackfillFixtureDB(dbPath, 2); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, insertErr := db.Exec(`
+insert into asset values ('asset:3', '2026-05-31T12:00:00Z');
+insert into location_observation
+select 'asset:3', latitude, longitude, horizontal_accuracy
+from location_observation where asset_id = 'asset:1';
+`)
+	closeErr := db.Close()
+	if insertErr != nil {
+		t.Fatal(insertErr)
+	}
+	if closeErr != nil {
+		t.Fatal(closeErr)
+	}
+
+	t.Setenv("PHOTOSCRAWL_TEST_PLACE_RAW_CHILD", "1")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	summary, backfillErr := Backfill(ctx, BackfillOptions{DatabasePath: dbPath, OutputDir: outDir})
+	for _, name := range []string{"attempts", "errors"} {
+		paths, err := filepath.Glob(filepath.Join(outDir, name, "*"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, path := range paths {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(data), "usage:") {
+				t.Errorf("%s contains a usage error: %s", path, data)
+			}
+		}
+		if name == "attempts" && len(paths) != 2 {
+			t.Errorf("attempt files = %d, want 2", len(paths))
+		}
+		if name == "errors" && len(paths) != 0 {
+			t.Errorf("error files = %d, want 0", len(paths))
+		}
+	}
+	if backfillErr != nil {
+		t.Fatal(backfillErr)
+	}
+	if summary.LocatedAssets != 3 || summary.LocationKeys != 2 || summary.Successes != 2 || summary.FinalFailures != 0 || summary.ProviderAttempts != 2 || summary.AttemptFailures != 0 {
+		t.Fatalf("unexpected backfill summary: %+v", summary)
+	}
+
+	data, err := os.ReadFile(filepath.Join(outDir, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var keys []backfillKey
+	if err := json.Unmarshal(data, &keys); err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("manifest keys = %d, want 2", len(keys))
+	}
+	want := []Coordinate{
+		{Latitude: 52.379189, Longitude: 4.899431},
+		{Latitude: 52.389189, Longitude: 4.899431},
+	}
+	for i, key := range keys {
+		path := filepath.Join(outDir, "outputs", key.filename()+".json")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var result Result
+		if err := json.Unmarshal(data, &result); err != nil {
+			t.Fatal(err)
+		}
+		if !sameCoordinate(result.Input.Location.Latitude, want[i].Latitude) || !sameCoordinate(result.Input.Location.Longitude, want[i].Longitude) || result.Input.AccuracyMeters != 8.5 || result.RadiusMeters != backfillRadiusMeters {
+			t.Fatalf("unexpected raw result: %+v", result)
+		}
+		if !outputMatches(path, key) {
+			t.Errorf("output does not match manifest key: %+v", key)
+		}
+	}
+	data, err = os.ReadFile(filepath.Join(outDir, "summary.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted BackfillResult
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if persisted != summary {
+		t.Fatalf("persisted summary = %+v, want %+v", persisted, summary)
+	}
+}

--- a/internal/place/run.go
+++ b/internal/place/run.go
@@ -63,6 +63,18 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 	return result, nil
 }
 
+func RunRaw(ctx context.Context, opts RawOptions) (Result, error) {
+	input, err := loadInput(opts.InputPath)
+	if err != nil {
+		return Result{}, err
+	}
+	radius := opts.RadiusMeters
+	if radius <= 0 {
+		radius = defaultRadiusMeters
+	}
+	return rawAppleResult(ctx, input, radius)
+}
+
 func LoadResult(path string) (Result, error) {
 	reader, closeReader, err := inputReader(path)
 	if err != nil {

--- a/internal/place/types.go
+++ b/internal/place/types.go
@@ -3,6 +3,8 @@ package place
 import "time"
 
 const (
+	RawContextCommand = "place-context-raw"
+
 	defaultRadiusMeters = 150.0
 	maxCandidates       = 12
 
@@ -15,6 +17,11 @@ type Options struct {
 	InputPath    string
 	RadiusMeters float64
 	CacheDir     string
+}
+
+type RawOptions struct {
+	InputPath    string
+	RadiusMeters float64
 }
 
 type Input struct {


### PR DESCRIPTION
## Problem

Apple place enrichment via `place-backfill` never succeeds. Every geocode attempt records the CLI usage text as the provider error and fails within milliseconds:

```
{"index":0,"attempt":1,...,"error":"usage: photoscrawl [--version] <version|metadata|...>","success":false}
```

## Root cause

`place-backfill` isolates each Apple CoreLocation/MapKit geocode by re-spawning the CLI as a subprocess with the `place-context-raw` command (`internal/place/backfill.go`, `rawAppleResultSubprocess`). That command was never registered in `cmd/photoscrawl/main.go` — the tooling commit (50fded6) only wired up `place-context`, `place-card`, and `place-backfill` — so the subprocess always got the usage error and exit 2. Not a rename or removal; the command never existed.

## Fix

- Register `place-context-raw` in the dispatch, backed by a new `place.RunRaw`: load input, call the raw Apple provider, no cache and no candidate calibration — this is the raw provider-evidence bridge the backfill persists, which is why it deliberately does not reuse `place.Run`.
- Export the command name as `place.RawContextCommand` and use it in both the backfill exec call and the dispatch, so they cannot drift again.
- Pass the backfill radius explicitly to the subprocess instead of relying on default drift.
- The bridge always emits bare JSON on stdout (its sole consumer is the backfill's `json.Unmarshal`).

## Tests

- Dispatch regression test: `run(ctx, {place.RawContextCommand, ...})` with an invalid input file must return an input-parse error, not `output.UsageError`. This reproduces the exact bug on the pre-fix dispatch.
- Hermetic end-to-end backfill test over a synthetic sqlite library (2 coordinate keys, 3 assets) that exercises the real subprocess spawn via a `TestMain` re-exec child, asserting the argv/stdin protocol, outputs matching manifest keys, summary/manifest persistence, and that no artifact contains a usage error.

## Proof with the built CLI

Same synthetic library, both binaries:

- pre-fix binary: attempt error is the usage string, recorded in ~60ms.
- fixed binary: the subprocess reaches Apple's real geocoder and spends the full 20s provider window; the recorded error on the test machine is the provider-level `Apple reverse geocode timed out` — an environmental geod condition that affects the long-registered `place-context` identically and predates this change.

`make check` passes (tidy, gofmt, vet, deadcode, full tests, smoke build).
