### PR TITLE
feat: import Apple photo details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.3.0 - 2026-09-01
+
+### Highlights
+
+- Import original camera and EXIF details, Photos edit state, and Apple quality scores as evidence-backed searchable observations.
+
 ## 0.2.0 - 2026-09-01
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ state. Every imported asset is queued for `classify`.
 `import-apple` makes verified, consistent copies of Apple Photos' live
 databases in a private temporary directory, reads those copies, and removes
 them when the import finishes. It
-adds Apple's existing named-person records and search index to `photos.sqlite`:
+adds Apple's existing named-person records, search index, original camera and
+EXIF details, edit state, and Photos quality scores to `photos.sqlite`:
 captions, keywords, detected text, scene labels, activities, venues, dates,
 places, people, camera/source clues, and photo types. Both the current
 `psi.sqlite` search index and the newer `leo.sqlite` layout are supported. The

--- a/internal/archive/apple_metadata.go
+++ b/internal/archive/apple_metadata.go
@@ -1,0 +1,428 @@
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/openclaw/crawlkit/store"
+)
+
+const photosLibraryDBMetadataModelID = "apple.photos.metadata"
+const photosLibraryDBMetadataVersion = "photos.sqlite.v1"
+
+type ImportPhotoMetadataResult struct {
+	Source                      string            `json:"source"`
+	ModelID                     string            `json:"model_id"`
+	PhotosDatabase              string            `json:"photos_database"`
+	Schema                      map[string]string `json:"schema"`
+	AssetsRead                  int               `json:"assets_read"`
+	AssetsResolved              int               `json:"assets_resolved"`
+	AssetsUnresolved            int               `json:"assets_unresolved"`
+	ExifObservationsInserted    int               `json:"exif_observations_inserted"`
+	QualityObservationsInserted int               `json:"quality_observations_inserted"`
+	EditObservationsInserted    int               `json:"edit_observations_inserted"`
+	AssetsTouched               int               `json:"assets_touched"`
+}
+
+type applePhotoMetadataRow struct {
+	assetUUID       string
+	exif            map[string]any
+	quality         map[string]any
+	adjustmentState any
+	hasAdjustments  bool
+}
+
+type photoMetadataImportInput struct {
+	schema map[string]string
+	rows   []applePhotoMetadataRow
+}
+
+var appleExifColumns = map[string]string{
+	"ZFLASHFIRED":     "flash_fired",
+	"ZISO":            "iso",
+	"ZMETERINGMODE":   "metering_mode",
+	"ZSAMPLERATE":     "sample_rate",
+	"ZTRACKFORMAT":    "track_format",
+	"ZWHITEBALANCE":   "white_balance",
+	"ZAPERTURE":       "aperture",
+	"ZBITRATE":        "bit_rate",
+	"ZDURATION":       "duration",
+	"ZEXPOSUREBIAS":   "exposure_bias",
+	"ZFOCALLENGTH":    "focal_length",
+	"ZFPS":            "frames_per_second",
+	"ZLATITUDE":       "latitude",
+	"ZLONGITUDE":      "longitude",
+	"ZSHUTTERSPEED":   "shutter_speed",
+	"ZCAMERAMAKE":     "camera_make",
+	"ZCAMERAMODEL":    "camera_model",
+	"ZCODEC":          "codec",
+	"ZLENSMODEL":      "lens_model",
+	"ZDATECREATED":    "date_created",
+	"ZTIMEZONEOFFSET": "timezone_offset",
+	"ZTIMEZONENAME":   "timezone_name",
+}
+
+var appleAssetScoreColumns = map[string]string{
+	"ZOVERALLAESTHETICSCORE":    "overall_aesthetic",
+	"ZCURATIONSCORE":            "curation",
+	"ZPROMOTIONSCORE":           "promotion",
+	"ZHIGHLIGHTVISIBILITYSCORE": "highlight_visibility",
+}
+
+var appleComputedScoreColumns = map[string]string{
+	"ZBEHAVIORALSCORE":              "behavioral",
+	"ZFAILURESCORE":                 "failure",
+	"ZHARMONIOUSCOLORSCORE":         "harmonious_color",
+	"ZIMMERSIVENESSSCORE":           "immersiveness",
+	"ZINTERACTIONSCORE":             "interaction",
+	"ZINTERESTINGSUBJECTSCORE":      "interesting_subject",
+	"ZINTRUSIVEOBJECTPRESENCESCORE": "intrusive_object_presence",
+	"ZLIVELYCOLORSCORE":             "lively_color",
+	"ZLOWLIGHT":                     "low_light",
+	"ZNOISESCORE":                   "noise",
+	"ZPLEASANTCAMERATILTSCORE":      "pleasant_camera_tilt",
+	"ZPLEASANTCOMPOSITIONSCORE":     "pleasant_composition",
+	"ZPLEASANTLIGHTINGSCORE":        "pleasant_lighting",
+	"ZPLEASANTPATTERNSCORE":         "pleasant_pattern",
+	"ZPLEASANTPERSPECTIVESCORE":     "pleasant_perspective",
+	"ZPLEASANTPOSTPROCESSINGSCORE":  "pleasant_post_processing",
+	"ZPLEASANTREFLECTIONSSCORE":     "pleasant_reflection",
+	"ZPLEASANTSYMMETRYSCORE":        "pleasant_symmetry",
+	"ZSHARPLYFOCUSEDSUBJECTSCORE":   "sharply_focused_subject",
+	"ZTASTEFULLYBLURREDSCORE":       "tastefully_blurred",
+	"ZWELLCHOSENSUBJECTSCORE":       "well_chosen_subject",
+	"ZWELLFRAMEDSUBJECTSCORE":       "well_framed_subject",
+	"ZWELLTIMEDSHOTSCORE":           "well_timed_shot",
+}
+
+func preflightPhotoMetadataImport(ctx context.Context, libraryPath string) (photoMetadataImportInput, error) {
+	liveDBPath := filepath.Join(libraryPath, "database", "Photos.sqlite")
+	snapshotPath, cleanup, err := copyPhotosSQLite(ctx, liveDBPath)
+	if err != nil {
+		return photoMetadataImportInput{}, err
+	}
+	defer cleanup()
+	photosDB, err := store.OpenReadOnly(ctx, snapshotPath)
+	if err != nil {
+		return photoMetadataImportInput{}, fmt.Errorf("open copied Photos sqlite for metadata: %w", err)
+	}
+	defer photosDB.Close()
+	return loadPhotoMetadataInput(ctx, photosDB.DB())
+}
+
+func loadPhotoMetadataInput(ctx context.Context, db *sql.DB) (photoMetadataImportInput, error) {
+	assetTable, err := firstExistingTable(ctx, db, "ZASSET", "ZGENERICASSET")
+	if err != nil {
+		return photoMetadataImportInput{}, err
+	}
+	assetColumns, err := tableColumns(ctx, db, assetTable)
+	if err != nil {
+		return photoMetadataImportInput{}, err
+	}
+	if !assetColumns["Z_PK"] || !assetColumns["ZUUID"] {
+		return photoMetadataImportInput{}, fmt.Errorf("unsupported Apple Photos metadata schema: %s lacks Z_PK or ZUUID", assetTable)
+	}
+	adjustmentColumn := "ZHASADJUSTMENTS"
+	if assetColumns["ZADJUSTMENTSSTATE"] {
+		adjustmentColumn = "ZADJUSTMENTSSTATE"
+	} else if !assetColumns[adjustmentColumn] {
+		return photoMetadataImportInput{}, fmt.Errorf("unsupported Apple Photos metadata schema: %s lacks adjustment state", assetTable)
+	}
+	for _, table := range []string{"ZEXTENDEDATTRIBUTES", "ZCOMPUTEDASSETATTRIBUTES"} {
+		columns, err := tableColumns(ctx, db, table)
+		if err != nil {
+			return photoMetadataImportInput{}, err
+		}
+		if !columns["ZASSET"] {
+			return photoMetadataImportInput{}, fmt.Errorf("unsupported Apple Photos metadata schema: %s lacks ZASSET", table)
+		}
+	}
+
+	byUUID := map[string]*applePhotoMetadataRow{}
+	ensure := func(uuid string) *applePhotoMetadataRow {
+		uuid = normalizeAssetLocalIdentifier(uuid)
+		row := byUUID[uuid]
+		if row == nil {
+			row = &applePhotoMetadataRow{assetUUID: uuid}
+			byUUID[uuid] = row
+		}
+		return row
+	}
+
+	editRows, err := metadataQueryRows(ctx, db, fmt.Sprintf("select a.ZUUID, a.%s as ZEDITSTATE from %s a", store.QuoteIdent(adjustmentColumn), store.QuoteIdent(assetTable)))
+	if err != nil {
+		return photoMetadataImportInput{}, fmt.Errorf("read Apple edit states: %w", err)
+	}
+	for _, values := range editRows {
+		row := ensure(stringValue(values["ZUUID"]))
+		row.adjustmentState = normalizedSQLiteValue(values["ZEDITSTATE"])
+		row.hasAdjustments = sqliteTruthy(values["ZEDITSTATE"])
+	}
+
+	exifRows, err := metadataQueryRows(ctx, db, fmt.Sprintf("select a.ZUUID, e.* from %s a join ZEXTENDEDATTRIBUTES e on e.ZASSET = a.Z_PK", store.QuoteIdent(assetTable)))
+	if err != nil {
+		return photoMetadataImportInput{}, fmt.Errorf("read Apple EXIF metadata: %w", err)
+	}
+	for _, values := range exifRows {
+		row := ensure(stringValue(values["ZUUID"]))
+		row.exif = selectMetadataValues(values, appleExifColumns)
+	}
+
+	assetScoreSelect := []string{"a.ZUUID"}
+	for _, column := range sortedMappedColumns(appleAssetScoreColumns) {
+		if assetColumns[column] {
+			assetScoreSelect = append(assetScoreSelect, "a."+store.QuoteIdent(column))
+		}
+	}
+	qualityRows, err := metadataQueryRows(ctx, db, fmt.Sprintf("select %s, c.* from %s a join ZCOMPUTEDASSETATTRIBUTES c on c.ZASSET = a.Z_PK", strings.Join(assetScoreSelect, ", "), store.QuoteIdent(assetTable)))
+	if err != nil {
+		return photoMetadataImportInput{}, fmt.Errorf("read Apple quality scores: %w", err)
+	}
+	qualityMap := map[string]string{}
+	for key, value := range appleAssetScoreColumns {
+		qualityMap[key] = value
+	}
+	for key, value := range appleComputedScoreColumns {
+		qualityMap[key] = value
+	}
+	for _, values := range qualityRows {
+		row := ensure(stringValue(values["ZUUID"]))
+		row.quality = selectMetadataValues(values, qualityMap)
+	}
+
+	rows := make([]applePhotoMetadataRow, 0, len(byUUID))
+	for uuid, row := range byUUID {
+		if uuid != "" {
+			rows = append(rows, *row)
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].assetUUID < rows[j].assetUUID })
+	return photoMetadataImportInput{
+		schema: map[string]string{
+			"asset_table":               assetTable,
+			"extended_attributes_table": "ZEXTENDEDATTRIBUTES",
+			"computed_attributes_table": "ZCOMPUTEDASSETATTRIBUTES",
+			"adjustment_column":         adjustmentColumn,
+		},
+		rows: rows,
+	}, nil
+}
+
+func writePhotoMetadataImport(ctx context.Context, tx *sql.Tx, input photoMetadataImportInput, assetByUUID map[string]string, importedAt time.Time) (ImportPhotoMetadataResult, map[string]bool, error) {
+	if err := clearImportedPhotoMetadata(ctx, tx); err != nil {
+		return ImportPhotoMetadataResult{}, nil, err
+	}
+	result := ImportPhotoMetadataResult{
+		Source:         photosLibraryDBFaceSource,
+		ModelID:        photosLibraryDBMetadataModelID,
+		PhotosDatabase: "database/Photos.sqlite",
+		Schema:         input.schema,
+		AssetsRead:     len(input.rows),
+	}
+	touched := map[string]bool{}
+	for _, row := range input.rows {
+		assetID, ok := assetByUUID[row.assetUUID]
+		if !ok {
+			result.AssetsUnresolved++
+			continue
+		}
+		result.AssetsResolved++
+		if len(row.exif) > 0 {
+			if err := insertPhotoMetadataObservation(ctx, tx, assetID, row.assetUUID, "apple_exif", row.exif, exifSummary(row.exif), "ZEXTENDEDATTRIBUTES", importedAt); err != nil {
+				return ImportPhotoMetadataResult{}, nil, err
+			}
+			result.ExifObservationsInserted++
+		}
+		if len(row.quality) > 0 {
+			if err := insertPhotoMetadataObservation(ctx, tx, assetID, row.assetUUID, "apple_quality_scores", row.quality, "Apple Photos quality scores", "ZCOMPUTEDASSETATTRIBUTES", importedAt); err != nil {
+				return ImportPhotoMetadataResult{}, nil, err
+			}
+			result.QualityObservationsInserted++
+		}
+		edit := map[string]any{"has_adjustments": row.hasAdjustments, "adjustment_state": row.adjustmentState}
+		editText := "not edited"
+		if row.hasAdjustments {
+			editText = "edited"
+		}
+		if err := insertPhotoMetadataObservation(ctx, tx, assetID, row.assetUUID, "apple_edit_state", edit, editText, input.schema["asset_table"], importedAt); err != nil {
+			return ImportPhotoMetadataResult{}, nil, err
+		}
+		result.EditObservationsInserted++
+		touched[assetID] = true
+	}
+	result.AssetsTouched = len(touched)
+	return result, touched, nil
+}
+
+func clearImportedPhotoMetadata(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `delete from observation_fts where id in (select id from model_observation where source = ? and model_id = ?)`, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID); err != nil {
+		return fmt.Errorf("clear Apple photo metadata search rows: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `delete from observation_term where observation_id in (select id from model_observation where source = ? and model_id = ?)`, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID); err != nil {
+		return fmt.Errorf("clear Apple photo metadata terms: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `delete from model_observation where source = ? and model_id = ?`, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID); err != nil {
+		return fmt.Errorf("clear Apple photo metadata observations: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `delete from evidence_ref where source = ? and evidence_kind = 'apple_photo_metadata'`, photosLibraryDBFaceSource); err != nil {
+		return fmt.Errorf("clear Apple photo metadata evidence: %w", err)
+	}
+	return nil
+}
+
+func insertPhotoMetadataObservation(ctx context.Context, tx *sql.Tx, assetID, assetUUID, observationType string, value map[string]any, valueText, table string, importedAt time.Time) error {
+	valueJSON, err := jsonText(value)
+	if err != nil {
+		return err
+	}
+	observationID := stableID("model_observation", assetID, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID, observationType)
+	evidenceID := stableID("evidence", assetID, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID, observationType)
+	evidenceJSON, err := jsonText(map[string]any{
+		"schema_source": "Photos.sqlite",
+		"table":         table,
+		"asset_uuid":    assetUUID,
+		"values":        value,
+		"imported_at":   importedAt.Format(time.RFC3339Nano),
+		"read_only":     true,
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `insert into evidence_ref(id, asset_id, evidence_kind, source, pointer, value_json) values (?, ?, 'apple_photo_metadata', ?, ?, ?)`, evidenceID, assetID, photosLibraryDBFaceSource, table+":"+assetUUID, evidenceJSON); err != nil {
+		return fmt.Errorf("write Apple photo metadata evidence: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `insert into model_observation(id, asset_id, observation_type, value_text, value_json, confidence, source, model_id, prompt_version, evidence_id) values (?, ?, ?, ?, ?, 1, ?, ?, ?, ?)`, observationID, assetID, observationType, valueText, valueJSON, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID, photosLibraryDBMetadataVersion, evidenceID); err != nil {
+		return fmt.Errorf("write Apple photo metadata observation: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `insert into observation_fts(id, asset_id, title, body) values (?, ?, ?, ?)`, observationID, assetID, valueText, metadataSearchText(observationType, valueText, value)); err != nil {
+		return fmt.Errorf("write Apple photo metadata search row: %w", err)
+	}
+	return nil
+}
+
+func firstExistingTable(ctx context.Context, db *sql.DB, names ...string) (string, error) {
+	for _, name := range names {
+		var found string
+		err := db.QueryRowContext(ctx, `select name from sqlite_master where type = 'table' and name = ?`, name).Scan(&found)
+		if err == nil {
+			return found, nil
+		}
+		if err != sql.ErrNoRows {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("unsupported Apple Photos metadata schema: none of %s exist", strings.Join(names, ", "))
+}
+
+func metadataQueryRows(ctx context.Context, db *sql.DB, query string) ([]map[string]any, error) {
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	out := []map[string]any{}
+	for rows.Next() {
+		values := make([]any, len(columns))
+		pointers := make([]any, len(columns))
+		for index := range values {
+			pointers[index] = &values[index]
+		}
+		if err := rows.Scan(pointers...); err != nil {
+			return nil, err
+		}
+		row := map[string]any{}
+		for index, column := range columns {
+			row[column] = normalizedSQLiteValue(values[index])
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func selectMetadataValues(values map[string]any, mapping map[string]string) map[string]any {
+	out := map[string]any{}
+	for column, key := range mapping {
+		value, ok := values[column]
+		if !ok || value == nil {
+			continue
+		}
+		out[key] = normalizedSQLiteValue(value)
+	}
+	return out
+}
+
+func normalizedSQLiteValue(value any) any {
+	if bytes, ok := value.([]byte); ok {
+		return string(bytes)
+	}
+	return value
+}
+
+func stringValue(value any) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(normalizedSQLiteValue(value)))
+}
+
+func sqliteTruthy(value any) bool {
+	switch typed := normalizedSQLiteValue(value).(type) {
+	case int64:
+		return typed != 0
+	case float64:
+		return typed != 0
+	case bool:
+		return typed
+	case string:
+		return typed != "" && typed != "0" && !strings.EqualFold(typed, "false")
+	default:
+		return false
+	}
+}
+
+func sortedMappedColumns(mapping map[string]string) []string {
+	columns := make([]string, 0, len(mapping))
+	for column := range mapping {
+		columns = append(columns, column)
+	}
+	sort.Strings(columns)
+	return columns
+}
+
+func exifSummary(exif map[string]any) string {
+	parts := []string{}
+	for _, key := range []string{"camera_make", "camera_model", "lens_model", "codec"} {
+		if value := stringValue(exif[key]); value != "" {
+			parts = append(parts, value)
+		}
+	}
+	if iso, ok := exif["iso"]; ok {
+		parts = append(parts, "ISO "+fmt.Sprint(iso))
+	}
+	if len(parts) == 0 {
+		return "Apple camera metadata"
+	}
+	return strings.Join(parts, " ")
+}
+
+func metadataSearchText(observationType, valueText string, values map[string]any) string {
+	parts := []string{observationType, strings.ReplaceAll(observationType, "_", " "), valueText, photosLibraryDBFaceSource}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		parts = append(parts, strings.ReplaceAll(key, "_", " "), fmt.Sprint(values[key]))
+	}
+	return strings.Join(nonEmpty(parts...), " ")
+}

--- a/internal/archive/control.go
+++ b/internal/archive/control.go
@@ -17,7 +17,7 @@ func ControlManifest(paths Paths) control.Manifest {
 		DefaultLogs:     paths.LogDir,
 		DefaultShare:    paths.ShareDir,
 	}
-	manifest.Capabilities = []string{"metadata", "status", "init", "search", "timeline", "face-observations", "apple-search-index"}
+	manifest.Capabilities = []string{"metadata", "status", "init", "search", "timeline", "face-observations", "apple-search-index", "apple-photo-metadata"}
 	manifest.Privacy = control.Privacy{
 		ExportsSecrets: false,
 		LocalOnlyScopes: []string{
@@ -27,6 +27,7 @@ func ControlManifest(paths Paths) control.Manifest {
 			"location-observations",
 			"face-observations",
 			"apple-search-index",
+			"apple-photo-metadata",
 			"local-model-observations",
 		},
 	}
@@ -34,7 +35,7 @@ func ControlManifest(paths Paths) control.Manifest {
 		"metadata":     {Title: "Metadata", Argv: []string{"photoscrawl", "metadata", "--json"}, JSON: true},
 		"status":       {Title: "Status", Argv: []string{"photoscrawl", "status", "--json"}, JSON: true},
 		"init":         {Title: "Initialize archive", Argv: []string{"photoscrawl", "init", "--json"}, JSON: true, Mutates: true},
-		"import_apple": {Title: "Import Apple search labels and people", Argv: []string{"photoscrawl", "import-apple", "--json"}, JSON: true, Mutates: true},
+		"import_apple": {Title: "Import Apple search labels, people, and photo metadata", Argv: []string{"photoscrawl", "import-apple", "--json"}, JSON: true, Mutates: true},
 		"query":        {Title: "Search", Argv: []string{"photoscrawl", "search", "--json", "--query"}, JSON: true},
 		"timeline":     {Title: "Timeline", Argv: []string{"photoscrawl", "timeline", "--json", "--from", "<from>", "--to", "<to>"}, JSON: true},
 	}

--- a/internal/archive/faces.go
+++ b/internal/archive/faces.go
@@ -26,14 +26,15 @@ type ImportAppleOptions struct {
 }
 
 type ImportAppleResult struct {
-	Database            string                  `json:"database"`
-	LibraryPath         string                  `json:"library_path"`
-	Faces               ImportFacesResult       `json:"faces"`
-	SearchIndex         ImportSearchIndexResult `json:"search_index"`
-	TotalAssetsTouched  int                     `json:"total_assets_touched"`
-	SyncStrategy        string                  `json:"sync_strategy"`
-	ImportedAt          string                  `json:"imported_at"`
-	OsxphotosReferences []string                `json:"osxphotos_references"`
+	Database            string                    `json:"database"`
+	LibraryPath         string                    `json:"library_path"`
+	Faces               ImportFacesResult         `json:"faces"`
+	SearchIndex         ImportSearchIndexResult   `json:"search_index"`
+	PhotoMetadata       ImportPhotoMetadataResult `json:"photo_metadata"`
+	TotalAssetsTouched  int                       `json:"total_assets_touched"`
+	SyncStrategy        string                    `json:"sync_strategy"`
+	ImportedAt          string                    `json:"imported_at"`
+	OsxphotosReferences []string                  `json:"osxphotos_references"`
 }
 
 type ImportFacesResult struct {
@@ -143,6 +144,10 @@ func ImportApple(ctx context.Context, paths Paths, opts ImportAppleOptions) (Imp
 	if err != nil {
 		return ImportAppleResult{}, err
 	}
+	metadataInput, err := preflightPhotoMetadataImport(ctx, libraryPath)
+	if err != nil {
+		return ImportAppleResult{}, err
+	}
 	archiveDB, err := openArchiveStore(ctx, paths.Database)
 	if err != nil {
 		return ImportAppleResult{}, err
@@ -165,10 +170,17 @@ func ImportApple(ctx context.Context, paths Paths, opts ImportAppleOptions) (Imp
 	if err != nil {
 		return ImportAppleResult{}, err
 	}
+	photoMetadata, metadataAssets, err := writePhotoMetadataImport(ctx, tx, metadataInput, assetByUUID, importedAt)
+	if err != nil {
+		return ImportAppleResult{}, err
+	}
 	if err := tx.Commit(); err != nil {
 		return ImportAppleResult{}, err
 	}
 	for assetID := range searchAssets {
+		faceAssets[assetID] = true
+	}
+	for assetID := range metadataAssets {
 		faceAssets[assetID] = true
 	}
 	return ImportAppleResult{
@@ -176,6 +188,7 @@ func ImportApple(ctx context.Context, paths Paths, opts ImportAppleOptions) (Imp
 		LibraryPath:        libraryPath,
 		Faces:              faces,
 		SearchIndex:        searchIndex,
+		PhotoMetadata:      photoMetadata,
 		TotalAssetsTouched: len(faceAssets),
 		SyncStrategy:       "atomic_authoritative_replace_by_source",
 		ImportedAt:         importedAt.Format(time.RFC3339Nano),
@@ -186,6 +199,9 @@ func ImportApple(ctx context.Context, paths Paths, opts ImportAppleOptions) (Imp
 			"osxphotos/photosdb/_photosdb_process_searchinfo.py:decode_leo_lexeme_ids",
 			"osxphotos/photosdb/_photosdb_process_searchinfo.py:ints_to_uuid",
 			"osxphotos/_constants.py:SearchCategory_Photos8",
+			"osxphotos/photosdb/_photosdb_process_exif.py:_process_exifinfo_5",
+			"osxphotos/photosdb/_photosdb_process_scoreinfo.py:_process_scoreinfo_5",
+			"osxphotos/_constants.py:HAS_ADJUSTMENTS",
 		},
 	}, nil
 }

--- a/internal/archive/faces_test.go
+++ b/internal/archive/faces_test.go
@@ -188,14 +188,28 @@ values ('existing-face', ?, 'existing', 'Existing Person', 1, '{}', ?, 'existing
 insert into visual_observation(id, asset_id, observation_type, label, confidence, bounding_box_json, source, model_id, evidence_id)
 values ('existing-search', ?, 'apple_label', 'Existing Label', 1, '{}', ?, ?, 'existing-search-evidence')
 `, assetID, photosSearchIndexSource, photosSearchIndexModelID)
+	execTestSQL(t, archiveDB.DB(), `
+insert into model_observation(id, asset_id, observation_type, value_text, value_json, confidence, source, model_id, prompt_version, evidence_id)
+values ('existing-metadata', ?, 'apple_exif', 'Existing Camera', '{}', 1, ?, ?, ?, 'existing-metadata-evidence')
+`, assetID, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID, photosLibraryDBMetadataVersion)
 	if err := archiveDB.Close(); err != nil {
 		t.Fatal(err)
 	}
 
 	libraryPath := filepath.Join(root, "Library.photoslibrary")
-	createTestPhotosDB(t, filepath.Join(libraryPath, "database", "Photos.sqlite"))
+	photosDBPath := filepath.Join(libraryPath, "database", "Photos.sqlite")
+	createTestPhotosDB(t, photosDBPath)
+	createTestPSIDB(t, filepath.Join(libraryPath, "database", "search", "psi.sqlite"))
+	brokenDB, err := sql.Open("sqlite", "file:"+photosDBPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	execTestSQL(t, brokenDB, `drop table ZCOMPUTEDASSETATTRIBUTES`)
+	if err := brokenDB.Close(); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := ImportApple(ctx, paths, ImportAppleOptions{LibraryPath: libraryPath}); err == nil {
-		t.Fatal("ImportApple() succeeded without a search index")
+		t.Fatal("ImportApple() succeeded with an unsupported metadata schema")
 	}
 
 	archiveDB, err = store.OpenReadOnly(ctx, paths.Database)
@@ -205,6 +219,7 @@ values ('existing-search', ?, 'apple_label', 'Existing Label', 1, '{}', ?, ?, 'e
 	defer archiveDB.Close()
 	assertCount(t, archiveDB.DB(), `select count(*) from face_observation where id = 'existing-face' and person_label = 'Existing Person'`, 1)
 	assertCount(t, archiveDB.DB(), `select count(*) from visual_observation where id = 'existing-search' and label = 'Existing Label'`, 1)
+	assertCount(t, archiveDB.DB(), `select count(*) from model_observation where id = 'existing-metadata' and value_text = 'Existing Camera'`, 1)
 }
 
 func TestImportSearchIndexIsIdempotent(t *testing.T) {
@@ -252,8 +267,21 @@ values (?, ?, 'image', '', '2026-07-06T00:00:00Z', '', '', '', 100, 100, 0, 0, 0
 	if err != nil {
 		t.Fatal(err)
 	}
+	combinedAgain, err := ImportApple(ctx, paths, ImportAppleOptions{LibraryPath: libraryPath})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if combined.SyncStrategy != "atomic_authoritative_replace_by_source" || combined.TotalAssetsTouched != 1 {
 		t.Fatalf("combined import = %#v", combined)
+	}
+	if combined.PhotoMetadata.ExifObservationsInserted != 1 || combined.PhotoMetadata.QualityObservationsInserted != 1 || combined.PhotoMetadata.EditObservationsInserted != 1 {
+		t.Fatalf("photo metadata import = %#v", combined.PhotoMetadata)
+	}
+	if combinedAgain.PhotoMetadata.ExifObservationsInserted != combined.PhotoMetadata.ExifObservationsInserted ||
+		combinedAgain.PhotoMetadata.QualityObservationsInserted != combined.PhotoMetadata.QualityObservationsInserted ||
+		combinedAgain.PhotoMetadata.EditObservationsInserted != combined.PhotoMetadata.EditObservationsInserted ||
+		combinedAgain.PhotoMetadata.AssetsTouched != combined.PhotoMetadata.AssetsTouched {
+		t.Fatalf("second photo metadata import = %#v, first %#v", combinedAgain.PhotoMetadata, combined.PhotoMetadata)
 	}
 	if first.GroupsRead != 3 || first.VisualObservationsInserted != 3 || first.PersonFaceObservationsInserted != 1 {
 		t.Fatalf("first import counts = %#v", first)
@@ -279,7 +307,16 @@ values (?, ?, 'image', '', '2026-07-06T00:00:00Z', '', '', '', 100, 100, 0, 0, 0
 	assertCount(t, archiveDB.DB(), `select count(*) from visual_observation where source = ?`, 3, photosSearchIndexSource)
 	assertCount(t, archiveDB.DB(), `select count(*) from face_observation where source = ?`, 1, photosSearchIndexSource)
 	assertCount(t, archiveDB.DB(), `select count(*) from evidence_ref where source = ? and evidence_kind = 'apple_search_index'`, 3, photosSearchIndexSource)
-	assertCount(t, archiveDB.DB(), `select count(*) from observation_fts where asset_id = ?`, 5, assetID)
+	assertCount(t, archiveDB.DB(), `select count(*) from observation_fts where asset_id = ?`, 8, assetID)
+	assertCount(t, archiveDB.DB(), `select count(*) from model_observation where asset_id = ? and source = ? and model_id = ?`, 3, assetID, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID)
+	assertCount(t, archiveDB.DB(), `select count(*) from evidence_ref where asset_id = ? and evidence_kind = 'apple_photo_metadata'`, 3, assetID)
+	metadataSearch, err := Search(ctx, paths, SearchOptions{Query: "iPhone", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metadataSearch.Results) != 1 || metadataSearch.Results[0].ObservationType != "apple_exif" {
+		t.Fatalf("metadata search = %#v", metadataSearch.Results)
+	}
 	status, err := Status(ctx, paths)
 	if err != nil {
 		t.Fatal(err)
@@ -354,9 +391,13 @@ func createTestPhotosDB(t *testing.T, path string) {
 	defer db.Close()
 	execTestSQL(t, db, `create table ZPERSON (Z_PK integer primary key, ZDISPLAYNAME text, ZFULLNAME text, ZPERSONUUID text)`)
 	execTestSQL(t, db, `create table ZDETECTEDFACE (Z_PK integer primary key, ZUUID text, ZPERSONFORFACE integer, ZASSETFORFACE integer, ZCENTERX real, ZCENTERY real, ZSIZE real, ZQUALITY real, ZNAMESOURCE integer, ZCLOUDNAMESOURCE integer, ZSOURCEWIDTH integer, ZSOURCEHEIGHT integer)`)
-	execTestSQL(t, db, `create table ZASSET (Z_PK integer primary key, ZUUID text)`)
+	execTestSQL(t, db, `create table ZASSET (Z_PK integer primary key, ZUUID text, ZADJUSTMENTSSTATE integer, ZOVERALLAESTHETICSCORE real, ZCURATIONSCORE real, ZPROMOTIONSCORE real, ZHIGHLIGHTVISIBILITYSCORE real)`)
+	execTestSQL(t, db, `create table ZEXTENDEDATTRIBUTES (Z_PK integer primary key, ZASSET integer, ZISO integer, ZFLASHFIRED integer, ZAPERTURE real, ZFOCALLENGTH real, ZCAMERAMAKE text, ZCAMERAMODEL text, ZLENSMODEL text, ZCODEC text)`)
+	execTestSQL(t, db, `create table ZCOMPUTEDASSETATTRIBUTES (Z_PK integer primary key, ZASSET integer, ZFAILURESCORE real, ZHARMONIOUSCOLORSCORE real, ZINTERESTINGSUBJECTSCORE real, ZPLEASANTCOMPOSITIONSCORE real, ZSHARPLYFOCUSEDSUBJECTSCORE real, ZWELLFRAMEDSUBJECTSCORE real)`)
 	execTestSQL(t, db, `insert into ZPERSON(Z_PK, ZDISPLAYNAME, ZFULLNAME, ZPERSONUUID) values (1, 'Alex', 'Alex', '08EA22FD-06A7-4145-829F-D724B9DD1BB6')`)
-	execTestSQL(t, db, `insert into ZASSET(Z_PK, ZUUID) values (1, '92D69D06-27F0-4831-AEC7-C6F640F075BA')`)
+	execTestSQL(t, db, `insert into ZASSET(Z_PK, ZUUID, ZADJUSTMENTSSTATE, ZOVERALLAESTHETICSCORE, ZCURATIONSCORE, ZPROMOTIONSCORE, ZHIGHLIGHTVISIBILITYSCORE) values (1, '92D69D06-27F0-4831-AEC7-C6F640F075BA', 1, 0.91, 0.82, 0.73, 0.64)`)
+	execTestSQL(t, db, `insert into ZEXTENDEDATTRIBUTES(Z_PK, ZASSET, ZISO, ZFLASHFIRED, ZAPERTURE, ZFOCALLENGTH, ZCAMERAMAKE, ZCAMERAMODEL, ZLENSMODEL, ZCODEC) values (1, 1, 100, 0, 1.8, 26, 'Apple', 'iPhone 15 Pro', 'iPhone 15 Pro back camera', 'HEVC')`)
+	execTestSQL(t, db, `insert into ZCOMPUTEDASSETATTRIBUTES(Z_PK, ZASSET, ZFAILURESCORE, ZHARMONIOUSCOLORSCORE, ZINTERESTINGSUBJECTSCORE, ZPLEASANTCOMPOSITIONSCORE, ZSHARPLYFOCUSEDSUBJECTSCORE, ZWELLFRAMEDSUBJECTSCORE) values (1, 1, 0.01, 0.75, 0.88, 0.92, 0.86, 0.94)`)
 	execTestSQL(t, db, `insert into ZDETECTEDFACE(Z_PK, ZUUID, ZPERSONFORFACE, ZASSETFORFACE, ZCENTERX, ZCENTERY, ZSIZE, ZQUALITY, ZNAMESOURCE, ZCLOUDNAMESOURCE, ZSOURCEWIDTH, ZSOURCEHEIGHT) values (1, 'face-1', 1, 1, 0.5, 0.5, 0.2, 0.9, 1, 0, 100, 100)`)
 }
 


### PR DESCRIPTION
## Summary

- import original camera and EXIF details from Photos.sqlite
- import Apple Photos edit state and quality scores
- store the details as searchable, evidence-backed observations
- refresh only this Apple-owned slice, atomically and idempotently
- fail closed before archive writes when the private Photos schema is unsupported

## Tests

- `GOWORK=off go test ./internal/archive ./cmd/photoscrawl`

Real-library proof requires the Foundation-signed release identity and will run from the exact v0.3.0 release after merge.