### PR TITLE
test(archive): stabilize live SQLite snapshot coverage

### DIFF
--- a/internal/archive/faces_test.go
+++ b/internal/archive/faces_test.go
@@ -85,8 +85,7 @@ func TestDecodeLeoLexemeIDs(t *testing.T) {
 }
 
 func TestCopySQLiteCreatesConsistentSnapshotWhileSourceIsLive(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx := context.Background()
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "live.sqlite")
 	db, err := sql.Open("sqlite", "file:"+sourcePath)
@@ -94,52 +93,85 @@ func TestCopySQLiteCreatesConsistentSnapshotWhileSourceIsLive(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
+	// Keep the connection-local WAL and cache settings on the writer connection.
+	db.SetMaxOpenConns(1)
 	if _, err := db.ExecContext(ctx, `
 pragma journal_mode = wal;
 pragma wal_autocheckpoint = 0;
+pragma cache_size = 1;
 create table paired(batch integer not null, side integer not null, payload blob, primary key(batch, side));
-with recursive batches(value) as (select 1 union all select value + 1 from batches where value < 2000)
+with recursive batches(value) as (select 1 union all select value + 1 from batches where value < 8)
 insert into paired(batch, side, payload)
 select value, side, zeroblob(2048) from batches cross join (select 1 as side union all select 2);
 `); err != nil {
 		t.Fatal(err)
 	}
+	committedWAL, err := os.Stat(sourcePath + "-wal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if committedWAL.Size() == 0 {
+		t.Fatal("fixture has no committed WAL data")
+	}
 
+	writeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	writerDone := make(chan error, 1)
 	writerStarted := make(chan struct{})
+	finishWrite := make(chan struct{})
 	go func() {
 		defer close(writerDone)
-		for batch := 2001; batch <= 2100; batch++ {
-			tx, err := db.BeginTx(ctx, nil)
-			if err == nil {
-				_, err = tx.ExecContext(ctx, `insert into paired(batch, side, payload) values (?, 1, zeroblob(2048)), (?, 2, zeroblob(2048))`, batch, batch)
-			}
-			if err == nil {
-				err = tx.Commit()
-			} else if tx != nil {
-				_ = tx.Rollback()
-			}
+		writerDone <- func() error {
+			tx, err := db.BeginTx(writeCtx, nil)
 			if err != nil {
-				writerDone <- err
-				return
+				return err
 			}
-			if batch == 2001 {
-				close(writerStarted)
+			defer tx.Rollback()
+			// Spill incomplete pairs to the WAL, then hold the transaction open
+			// throughout the copy so overlap does not depend on scheduling.
+			if _, err := tx.ExecContext(writeCtx, `insert into paired(batch, side, payload) select batch + 8, 1, payload from paired where side = 1 and batch <= 8`); err != nil {
+				return err
 			}
-			time.Sleep(100 * time.Microsecond)
-		}
-		writerDone <- nil
+			close(writerStarted)
+			select {
+			case <-finishWrite:
+			case <-writeCtx.Done():
+				return writeCtx.Err()
+			}
+			if _, err := tx.ExecContext(writeCtx, `insert into paired(batch, side, payload) select batch + 8, 2, payload from paired where side = 2 and batch <= 8`); err != nil {
+				return err
+			}
+			return tx.Commit()
+		}()
 	}()
-	<-writerStarted
+	defer func() {
+		cancel()
+		<-writerDone
+	}()
+	select {
+	case <-writerStarted:
+	case err := <-writerDone:
+		t.Fatalf("writer failed before snapshot: %v", err)
+	case <-writeCtx.Done():
+		t.Fatal(writeCtx.Err())
+	}
+	pendingWAL, err := os.Stat(sourcePath + "-wal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pendingWAL.Size() <= committedWAL.Size() {
+		t.Fatal("writer did not spill uncommitted data to the WAL")
+	}
 
-	snapshotPath, cleanup, copyErr := copySQLite(ctx, sourcePath, "photoscrawl-snapshot-test-")
-	if writerErr := <-writerDone; writerErr != nil {
-		t.Fatal(writerErr)
-	}
-	if copyErr != nil {
-		t.Fatal(copyErr)
-	}
+	snapshotPath, cleanup, err := copySQLite(writeCtx, sourcePath, "photoscrawl-snapshot-test-")
 	defer cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(finishWrite)
+	if err := <-writerDone; err != nil {
+		t.Fatal(err)
+	}
+	assertCount(t, db, `select count(*) from paired`, 32)
 
 	snapshot, err := store.OpenReadOnly(ctx, snapshotPath)
 	if err != nil {
@@ -153,6 +185,8 @@ select value, side, zeroblob(2048) from batches cross join (select 1 as side uni
 	if integrity != "ok" {
 		t.Fatalf("snapshot integrity = %q", integrity)
 	}
+	assertCount(t, snapshot.DB(), `select count(*) from paired where batch <= 8`, 16)
+	assertCount(t, snapshot.DB(), `select count(*) from paired where batch > 8`, 0)
 	var incompleteBatches int
 	if err := snapshot.DB().QueryRowContext(ctx, `select count(*) from (select batch from paired group by batch having count(*) <> 2)`).Scan(&incompleteBatches); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Make `TestCopySQLiteCreatesConsistentSnapshotWhileSourceIsLive` deterministic and inexpensive on slower or loaded Macs, without raising its 10-second timeout or changing production snapshot behavior.

The original test, added in #14, shared one deadline across a 4,000-row fixture, 100 durable write transactions, snapshot retries, and verification. Its roughly 16.6 MB retained WAL was repeatedly copied and hashed when concurrent commits changed the source. `wal_autocheckpoint=0` prevents checkpointing; it does not disable commit synchronization.

## Diagnosis

The initial pristine three-run check passed, demonstrating the load sensitivity. Later instrumented baseline runs reproduced two deadline failures in three attempts (11.32s and 11.77s). Setup took 1.53–4.90s, the writer took 3.54–5.14s, and snapshotting took 4.99–7.98s; writer and snapshot phases overlap and these ranges are not additive.

Quiet-source probes of the original fixture took 45–58ms with retained WAL versus 37–48ms after checkpointing. Inspection found ordinary bounded copy/hash retries plus SQLite recovery/`quick_check`, not an autocheckpoint-specific pathology warranting a production change. The existing five-attempt copy policy remains unchanged.

## Change

Seed eight complete pairs before starting the concurrency timeout. Pin the writer to one connection, use a small page cache to spill uncommitted rows into the WAL, and use channels to hold an incomplete transaction open throughout the snapshot. Finish and commit that transaction only after copying returns. This replaces sleep-based scheduling and the 100-commit workload with guaranteed open-transaction overlap.

The test explicitly verifies committed WAL presence, WAL growth from uncommitted writes, all committed pairs in the snapshot, exclusion of incomplete pairs, database integrity, and successful writer completion. Failure paths cancel and join the writer. Durability settings and the 10-second concurrency deadline are unchanged. All fixtures are synthetic and temporary; no live Photos data is accessed.

This is test-only, so there is no user-facing behavior, documentation, or changelog change.

## Validation

- `GOWORK=off go test -v -count=10 -run '^TestCopySQLiteCreatesConsistentSnapshotWhileSourceIsLive$' ./internal/archive/` — passed; independent final run: 10/10, 0.01–0.14s each, 0.730s package total.
- `GOWORK=off go test -race -count=3 -run '^TestCopySQLiteCreatesConsistentSnapshotWhileSourceIsLive$' ./internal/archive/` — passed.
- `make check` — passed all module, formatting, vet, dead-code, full-suite, and build/version gates. The linker emitted duplicate `-lobjc` warnings.
- `git diff --check` — passed.
- Codex autoreview — scoped-clean, no accepted/actionable findings at its default P0 scope.

Leave this PR open for review; do not merge automatically.
