### PR TITLE
docs(release): prepare 0.3.1 maintenance notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Prefer the Go 1.27.1 build toolchain and update modernc SQLite to v1.58.0, retaining the Go 1.27.0 source minimum, SQLite's required libc v1.75.6, and macOS 13 support.
+- Update SQLite to v1.58.0 and prefer Go 1.27.1 for source builds; Go 1.27.0 and macOS 13 remain supported.
 
 ## 0.3.0 - 2026-09-01
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ evidence supports each result.
 
 Current builds require macOS 13 Ventura or later on Apple silicon or Intel. `photoscrawl` uses
 native Objective-C/CGO bridges to PhotoKit, CoreLocation, MapKit, CoreImage,
-CoreGraphics, and ImageIO, so v0.1.x release archives are intentionally
+CoreGraphics, and ImageIO, so release archives are intentionally
 Darwin-only. Download the archive for your architecture from GitHub Releases,
 extract `photoscrawl`, and place it on your `PATH`.
 


### PR DESCRIPTION
Current installation guidance still limits Darwin-only archives to v0.1.x, even though the native Apple framework bridges and current releases retain that requirement. Apply the wording to all current release archives and lead the Unreleased note with the SQLite update, keeping the supported Go and macOS minimums explicit.

The proposed release is patch 0.3.1. Since v0.3.0, main contains the SQLite/Go toolchain maintenance from #23 and the synthetic SQLite snapshot test stabilization from #22. This PR changes documentation only and does not include the pending PhotoKit export-timeout proposal in #10.

Validation passed: full `make check`, the built Darwin CLI against a two-asset synthetic SQLite Photos library, and pre-commit plus committed-branch P0–P2 autoreview. [CI passed on the exact head](https://github.com/openclaw/photoscrawl/actions/runs/33983806598). The proof comment records the commands, results, and a local temporary-directory contention retry.

No release, tag, or publication is performed by this PR.
