### PR TITLE
fix(archive): stop the live SQLite snapshot test from asserting machine speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Name the SQLite source in snapshot cancellation errors so an aborted Photos snapshot reports which database it was copying.
+
 ## 0.3.2 - 2026-09-05
 
 ### Highlights

--- a/internal/archive/faces.go
+++ b/internal/archive/faces.go
@@ -495,7 +495,7 @@ func copySQLite(ctx context.Context, liveDBPath string, tempPrefix string) (stri
 	for attempt := 1; attempt <= 5; attempt++ {
 		if err := ctx.Err(); err != nil {
 			cleanup()
-			return "", func() {}, err
+			return "", func() {}, fmt.Errorf("snapshot SQLite source %s: %w", liveDBPath, err)
 		}
 		_ = os.Remove(dest)
 		_ = os.Remove(dest + "-wal")

--- a/internal/archive/faces_test.go
+++ b/internal/archive/faces_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/openclaw/crawlkit/store"
 )
@@ -114,7 +113,10 @@ select value, side, zeroblob(2048) from batches cross join (select 1 as side uni
 		t.Fatal("fixture has no committed WAL data")
 	}
 
-	writeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	// Cancel on cleanup only. copySQLite is I/O bound, so a wall-clock budget
+	// here would assert how fast the machine is rather than whether the
+	// snapshot is consistent; go test's own timeout is the hang backstop.
+	writeCtx, cancel := context.WithCancel(ctx)
 	writerDone := make(chan error, 1)
 	writerStarted := make(chan struct{})
 	finishWrite := make(chan struct{})
@@ -151,8 +153,6 @@ select value, side, zeroblob(2048) from batches cross join (select 1 as side uni
 	case <-writerStarted:
 	case err := <-writerDone:
 		t.Fatalf("writer failed before snapshot: %v", err)
-	case <-writeCtx.Done():
-		t.Fatal(writeCtx.Err())
 	}
 	pendingWAL, err := os.Stat(sourcePath + "-wal")
 	if err != nil {


### PR DESCRIPTION
## Problem

`TestCopySQLiteCreatesConsistentSnapshotWhileSourceIsLive` fails reliably on a loaded Mac with `context deadline exceeded`, both in isolation and under `make check`. It still fails on current `main` — **7 of 10 runs**, with individual runs taking 27–83s:

```
--- FAIL: TestCopySQLiteCreatesConsistentSnapshotWhileSourceIsLive (36.67s)
    faces_test.go:168: context deadline exceeded
--- FAIL: TestCopySQLiteCreatesConsistentSnapshotWhileSourceIsLive (83.53s)
    faces_test.go:168: context deadline exceeded
```

## Root cause

`copySQLite` is not doing anything pathological with WAL, and the seed volume is not the remaining problem — #22 already shrank the fixture to 16 rows and moved seeding outside the deadline.

The real cost is `verifySQLiteSnapshot`: every attempt opens the copied snapshot read-only and runs `pragma quick_check`. Instrumenting the phases on the affected machine:

```
seed                   1.788s
copyFiles             16.65ms
hash                  0.146ms
OpenReadOnly           2.401s   <-- the whole cost
quick_check           0.085ms
```

Opening the connection is the entire expense — and it is not WAL-related. A standalone probe that opens a **brand-new, empty** SQLite database with the same driver shows the same thing:

```
#0 open+ping 2.344s   #6 open+ping 5.845s   #10 open+ping 161ms
plain os.Create + Sync: 54ms / 77ms / 114ms
```

A bare `os.Create`+`Sync` costing 50–115ms is the tell: this is machine-level I/O saturation (load average ~28 during these runs), not a defect in the snapshot path. `copySQLite` retries up to 5 times, and each retry pays that open again, so a 10-second budget is exhausted long before the work itself is unreasonable. CI passes because CI is idle.

So the 10-second context was doing two jobs, and only one of them was intended: cancelling the writer goroutine at cleanup, and — accidentally — asserting how fast the machine is.

## Fix

Use `context.WithCancel` instead of `context.WithTimeout`. The context still cancels the writer goroutine during cleanup, which is what the test actually needs it for, and `go test`'s own timeout remains the hang backstop (and gives a goroutine dump instead of a bare `context deadline exceeded`). The now-unreachable `writeCtx.Done()` arm of the writer-start select is dropped.

The timeout is not raised, because the copy is not genuinely slow — it is removed as an assertion the test was never meant to make.

**Nothing the test verifies changes.** The fixture still commits WAL data, the writer still spills uncommitted pages to the WAL and holds its transaction open across the copy, and the snapshot is still checked for integrity, the 16 committed rows, zero uncommitted rows, and zero partial write batches.

Separately, `copySQLite` returned a bare `ctx.Err()` on cancellation, which is why this failure only ever said `context deadline exceeded` with no mention of the snapshot. It now names the source path, wrapped with `%w`.

## Proof

Run on the same machine, under the same load that produced the failures above:

- Focused test `-count=10`: **10/10 pass** (was 7/10 failing) at load average ~31
- `-race -count=3`: pass
- `make check`: green (tidy-check, fmt, vet, deadcode, full test suite, smoke)
- Codex autoreview at P0–P2: `scoped-clean`
