### PR TITLE
fix: preserve Photos archive data and bound original downloads

### DIFF
--- a/.github/scripts/test_vulncheck.py
+++ b/.github/scripts/test_vulncheck.py
@@ -1,0 +1,127 @@
+import json
+import unittest
+
+import vulncheck
+
+
+class StructuredScanTest(unittest.TestCase):
+    def setUp(self):
+        self.expected = {"scanner_version": "v1.7.0", "go_version": "go1.27.1"}
+        self.packages = {
+            "roots": ["example.invalid/app"],
+            "modules": {"example.invalid/app": "", "stdlib": "v1.27.1"},
+        }
+        self.messages = [
+            {"config": dict(self.expected)},
+            {"SBOM": {
+                "go_version": "go1.27.1", "roots": list(self.packages["roots"]),
+                "modules": [{"path": path, "version": version} for path, version in self.packages["modules"].items()],
+            }},
+        ]
+
+    def evaluate(self, extra=()):
+        text = "\n".join(json.dumps(value) for value in self.messages + list(extra))
+        return vulncheck.evaluate(text, self.expected, self.packages)
+
+    def test_candidate_is_not_a_finding(self):
+        result = self.evaluate([{"osv": {"id": "GO-2099-0001"}}])
+        self.assertEqual(result["candidate_advisories"], 1)
+        self.assertFalse(result["findings_require_review"])
+
+    def test_highest_trace_per_advisory(self):
+        messages = []
+        for index, frames in enumerate([
+            [{"module": "example.invalid/module"}],
+            [{"module": "example.invalid/module", "package": "example.invalid/module/pkg"}],
+            [
+                {"module": "example.invalid/module"},
+                {"module": "example.invalid/module", "package": "example.invalid/module/pkg", "function": "Called"},
+            ],
+        ], 1):
+            identifier = "GO-2099-000" + str(index)
+            messages.append({"osv": {"id": identifier}})
+            for frame in frames:
+                messages.append({"finding": {"osv": identifier, "trace": [frame]}})
+        result = self.evaluate(messages)
+        self.assertEqual(result["module_only"], ["GO-2099-0001"])
+        self.assertEqual(result["imported_only"], ["GO-2099-0002"])
+        self.assertEqual(result["called"], ["GO-2099-0003"])
+        self.assertTrue(result["findings_require_review"])
+
+    def test_missing_or_wrong_config_fails(self):
+        for text in ("", "{}", '{"progress": {}}', '{"config": {}}'):
+            with self.subTest(text=text), self.assertRaises(ValueError):
+                vulncheck.evaluate(text, self.expected, self.packages)
+
+    def test_duplicate_config_or_fatal_message_fails(self):
+        for message in ({"config": self.expected}, {"error": "load failed"}):
+            with self.subTest(message=message), self.assertRaises(ValueError):
+                self.evaluate([message])
+
+    def test_truncated_output_fails(self):
+        text = "\n".join(json.dumps(value) for value in self.messages)
+        with self.assertRaises(ValueError):
+            vulncheck.evaluate(text + '\n{"finding":', self.expected, self.packages)
+
+    def test_missing_or_wrong_sbom_fails(self):
+        for sbom in (None, {"go_version": "go1.27.0"}):
+            self.messages = [{"config": self.expected}]
+            if sbom is not None:
+                self.messages.append({"SBOM": sbom})
+            with self.subTest(sbom=sbom), self.assertRaises(ValueError):
+                self.evaluate()
+
+    def test_finding_requires_trace_and_advisory(self):
+        for finding in (
+            {"osv": "GO-2099-0001", "trace": []},
+            {"osv": "GO-2099-0001", "trace": [{"module": "example.invalid/module"}]},
+        ):
+            with self.subTest(finding=finding), self.assertRaises(ValueError):
+                self.evaluate([{"finding": finding}])
+
+    def test_goenv_off_reports_an_empty_filename(self):
+        environment = {"GOENV": "", "GOTOOLCHAIN": "local", "GOWORK": "off", "GOFLAGS": "-mod=readonly -p=1"}
+        vulncheck.validate_environment(environment, "off")
+        for requested, reported in ((None, ""), ("off", "off"), ("off", "/fixture/go.env")):
+            with self.subTest(requested=requested, reported=reported), self.assertRaises(ValueError):
+                vulncheck.validate_environment({**environment, "GOENV": reported}, requested)
+        for key, value in (("GOTOOLCHAIN", "auto"), ("GOWORK", "/fixture/go.work"), ("GOFLAGS", "-tags=fixture")):
+            with self.subTest(key=key), self.assertRaises(ValueError):
+                vulncheck.validate_environment({**environment, key: value}, "off")
+
+    def test_scan_roots_must_match_loaded_packages(self):
+        for roots in ([], ["example.invalid/other"], self.packages["roots"] * 2):
+            self.messages[1]["SBOM"]["roots"] = roots
+            with self.subTest(roots=roots), self.assertRaises(ValueError):
+                self.evaluate()
+
+    def test_scan_modules_must_match_loaded_versions(self):
+        modules = self.messages[1]["SBOM"]["modules"]
+        for scanned in ([], modules[:-1], modules * 2, [{"path": "stdlib", "version": "v1.27.0"}, modules[0]]):
+            self.messages[1]["SBOM"]["modules"] = scanned
+            with self.subTest(modules=scanned), self.assertRaises(ValueError):
+                self.evaluate()
+
+    def test_expected_modules_use_loaded_not_unused_selected_dependencies(self):
+        root = {"Path": "example.invalid/app", "Main": True}
+        dependency = {"Path": "example.invalid/dependency", "Version": "v1.2.3"}
+        selected = [root, dependency, {"Path": "example.invalid/unused", "Version": "v1.0.0"}]
+        loaded = [
+            {"ImportPath": "fmt", "DepOnly": True},
+            {"ImportPath": "example.invalid/dependency/pkg", "DepOnly": True, "Module": dependency},
+            {"ImportPath": "example.invalid/app", "Module": root},
+        ]
+        result = vulncheck.expected_sbom("\n".join(map(json.dumps, loaded)), selected, "go1.27.1")
+        self.assertEqual(result, {
+            "roots": ["example.invalid/app"],
+            "modules": {"stdlib": "v1.27.1", "example.invalid/app": "", "example.invalid/dependency": "v1.2.3"},
+        })
+        for packages in ([], [{"Error": {"Err": "load failed"}}], [
+            {"ImportPath": "example.invalid/app", "Module": {**root, "Version": "v9.0.0"}},
+        ]):
+            with self.subTest(packages=packages), self.assertRaises(ValueError):
+                vulncheck.expected_sbom("\n".join(map(json.dumps, packages)), selected, "go1.27.1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/vulncheck.py
+++ b/.github/scripts/vulncheck.py
@@ -1,0 +1,273 @@
+"""CI-only frozen Go advisory staging and structured scan verification."""
+
+import argparse
+import concurrent.futures
+import datetime
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import urllib.request
+
+
+def json_stream(text):
+    decoder = json.JSONDecoder()
+    offset = 0
+    while offset < len(text):
+        while offset < len(text) and text[offset].isspace():
+            offset += 1
+        if offset == len(text):
+            break
+        value, offset = decoder.raw_decode(text, offset)
+        if not isinstance(value, dict):
+            raise ValueError("expected a JSON object")
+        yield value
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def command(*args):
+    return subprocess.check_output(args, text=True, timeout=120)
+
+
+def public_bytes(path):
+    with urllib.request.urlopen("https://vuln.go.dev/" + path, timeout=30) as response:
+        return response.read()
+
+
+def graph():
+    text = command("go", "list", "-m", "-json", "all")
+    modules = list(json_stream(text))
+    if not modules or any(module.get("Replace") for module in modules):
+        raise ValueError("missing or replaced selected module graph")
+    return text, {module["Path"] for module in modules} | {"stdlib", "toolchain"}
+
+
+def required_records(index, paths):
+    records = {}
+    for module in index:
+        if module["path"] in paths:
+            for record in module["vulns"]:
+                if not re.fullmatch(r"GO-\d{4}-\d+", record["id"]):
+                    raise ValueError("invalid advisory record ID")
+                records[record["id"]] = record["modified"]
+    return records
+
+
+def file_hashes(directory):
+    return {
+        str(path.relative_to(directory)): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(directory.rglob("*.json"))
+        if path.name != "frozen.json"
+    }
+
+
+def stage(directory):
+    directory.mkdir(parents=True, exist_ok=False)
+    (directory / "index").mkdir()
+    (directory / "ID").mkdir()
+    _, paths = graph()
+    for name in ("db", "modules"):
+        data = gzip.decompress(public_bytes("index/" + name + ".json.gz"))
+        json.loads(data)
+        (directory / "index" / (name + ".json")).write_bytes(data)
+    index = json.loads((directory / "index/modules.json").read_text())
+    records = required_records(index, paths)
+
+    def fetch(item):
+        identifier, modified = item
+        data = public_bytes("ID/" + identifier + ".json")
+        record = json.loads(data)
+        if record["id"] != identifier or record["modified"] != modified:
+            raise ValueError("advisory changed while staging: " + identifier)
+        (directory / "ID" / (identifier + ".json")).write_bytes(data)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+        list(pool.map(fetch, sorted(records.items())))
+    database = json.loads((directory / "index/db.json").read_text())
+    if json.loads(gzip.decompress(public_bytes("index/db.json.gz"))) != database:
+        raise ValueError("advisory index changed while staging")
+    write_json(directory / "frozen.json", {
+        "retrieved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "source": "https://vuln.go.dev",
+        "database": database,
+        "module_paths": sorted(paths),
+        "records": sorted(records),
+        "files": file_hashes(directory),
+    })
+
+
+def expected_sbom(text, selected, version):
+    selected_versions = {module["Path"]: module.get("Version", "") for module in selected}
+    roots = set()
+    modules = {"stdlib": "v" + version.removeprefix("go")}
+    for package in json_stream(text):
+        if package.get("Error") or package.get("DepsErrors") or package.get("Incomplete"):
+            raise ValueError("package graph did not load completely")
+        if not package.get("DepOnly"):
+            roots.add(package["ImportPath"])
+        module = package.get("Module")
+        if module is None:
+            continue
+        path, module_version = module["Path"], module.get("Version", "")
+        if module.get("Replace") or module.get("Error") or selected_versions.get(path) != module_version:
+            raise ValueError("loaded package module differs from selected graph")
+        modules[path] = module_version
+    if not roots:
+        raise ValueError("no packages match the scan pattern")
+    return {"roots": sorted(roots), "modules": modules}
+
+
+def evaluate(text, expected, packages):
+    messages = list(json_stream(text))
+    if not messages or set(messages[0]) != {"config"}:
+        raise ValueError("missing initial scanner Config")
+    if sum("config" in message for message in messages) != 1:
+        raise ValueError("duplicate scanner Config")
+    config = messages[0]["config"]
+    for key, value in expected.items():
+        if config.get(key) != value:
+            raise ValueError("scanner Config mismatch: " + key)
+    levels = {}
+    candidates = set()
+    sboms = []
+    for message in messages:
+        if len(message) != 1 or not set(message) <= {"config", "progress", "SBOM", "osv", "finding"}:
+            raise ValueError("unexpected scanner message")
+        if "SBOM" in message:
+            sboms.append(message["SBOM"])
+        if "osv" in message:
+            candidates.add(message["osv"]["id"])
+        if "finding" not in message:
+            continue
+        finding = message["finding"]
+        trace = finding.get("trace")
+        if not finding.get("osv") or not trace or not trace[0].get("module"):
+            raise ValueError("incomplete finding")
+        frame = trace[0]
+        level = 3 if frame.get("function") else 2 if frame.get("package") else 1
+        levels[finding["osv"]] = max(levels.get(finding["osv"], 0), level)
+    if len(sboms) != 1 or sboms[0].get("go_version") != expected["go_version"]:
+        raise ValueError("missing or mismatched scanner SBOM")
+    roots = sboms[0].get("roots", [])
+    if not roots or len(set(roots)) != len(roots) or set(roots) != set(packages["roots"]):
+        raise ValueError("scanner roots differ from loaded packages")
+    scanned_modules = {}
+    for module in sboms[0].get("modules", []):
+        path = module.get("path")
+        if not path or path in scanned_modules:
+            raise ValueError("missing or duplicate scanner module")
+        scanned_modules[path] = module.get("version", "")
+    if scanned_modules != packages["modules"]:
+        raise ValueError("scanner modules differ from loaded package graph")
+    if not set(levels) <= candidates:
+        raise ValueError("finding without its advisory evidence")
+    return {
+        "candidate_advisories": len(candidates),
+        "called": sorted(key for key, level in levels.items() if level == 3),
+        "imported_only": sorted(key for key, level in levels.items() if level == 2),
+        "module_only": sorted(key for key, level in levels.items() if level == 1),
+        "findings_require_review": bool(levels),
+    }
+
+
+def validate_environment(environment, goenv):
+    # `go env GOENV` reports the resolved filename, empty when GOENV=off.
+    if goenv != "off" or environment.get("GOENV") != "":
+        raise ValueError("Go environment file is not disabled")
+    if any(environment.get(key) != value for key, value in {
+        "GOTOOLCHAIN": "local", "GOWORK": "off",
+    }.items()) or "tags" in environment["GOFLAGS"]:
+        raise ValueError("unexpected toolchain/workspace/build-tag configuration")
+
+
+def scan(database, scanner, output, version, platform):
+    output.mkdir(parents=True, exist_ok=False)
+    frozen = json.loads((database / "frozen.json").read_text())
+    if file_hashes(database) != frozen["files"]:
+        raise ValueError("frozen advisory bytes changed")
+    selected, paths = graph()
+    required = required_records(json.loads((database / "index/modules.json").read_text()), paths)
+    if not set(required) <= set(frozen["records"]):
+        raise ValueError("frozen database does not cover the selected graph")
+    (output / "modules.json").write_text(selected)
+    (output / "module-graph.txt").write_text(command("go", "mod", "graph"))
+    environment = json.loads(command(
+        "go", "env", "-json", "GOVERSION", "GOOS", "GOARCH", "CGO_ENABLED",
+        "GOFLAGS", "GOTOOLCHAIN", "GOWORK", "GOENV"))
+    if environment["GOVERSION"] != version or environment["GOOS"] != platform:
+        raise ValueError("actual compiler or platform mismatch")
+    validate_environment(environment, os.environ.get("GOENV"))
+    loaded = command("go", "list", "-deps", "-json", "./...")
+    (output / "loaded-packages.json").write_text(loaded)
+    packages = expected_sbom(loaded, list(json_stream(selected)), version)
+    write_json(output / "expected-sbom.json", packages)
+    db_uri = database.resolve().as_uri()
+    argv = [str(scanner), "-db=" + db_uri, "-json", "./..."]
+    write_json(output / "invocation.json", {
+        "source": command("git", "rev-parse", "HEAD").strip(),
+        "environment": environment,
+        "requested_goenv": os.environ["GOENV"],
+        "build_tags": [],
+        "scanner_sha256": hashlib.sha256(scanner.read_bytes()).hexdigest(),
+        "database_manifest_sha256": hashlib.sha256((database / "frozen.json").read_bytes()).hexdigest(),
+        "argv": argv,
+    })
+    (output / "scanner-build.txt").write_text(command("go", "version", "-m", str(scanner)))
+    completed = False
+    exit_code = None
+    try:
+        with (output / "scan.json").open("w") as stdout, (output / "scan.stderr").open("w") as stderr:
+            result = subprocess.run(
+                argv, stdout=stdout, stderr=stderr, timeout=600, check=False,
+                env={**os.environ, "GOPROXY": "off", "GOSUMDB": "off"})
+            completed, exit_code = True, result.returncode
+    finally:
+        write_json(output / "completion.json", {"completed": completed, "exit_code": exit_code})
+    if not completed or exit_code != 0:
+        raise ValueError("scanner failed or did not complete")
+    if file_hashes(database) != frozen["files"]:
+        raise ValueError("frozen advisory bytes changed during scan")
+    summary = evaluate((output / "scan.json").read_text(), {
+        "protocol_version": "v1.0.0", "scanner_name": "govulncheck",
+        "scanner_version": "v1.7.0", "db": db_uri,
+        "db_last_modified": frozen["database"]["modified"],
+        "go_version": version, "scan_level": "symbol", "scan_mode": "source",
+    }, packages)
+    write_json(output / "summary.json", summary)
+    print(json.dumps(summary, sort_keys=True))
+    if summary["findings_require_review"]:
+        raise ValueError("advisory findings require an explicit disposition")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    prepare = commands.add_parser("stage")
+    prepare.add_argument("database", type=Path)
+    run = commands.add_parser("scan")
+    run.add_argument("database", type=Path)
+    run.add_argument("scanner", type=Path)
+    run.add_argument("output", type=Path)
+    run.add_argument("version")
+    run.add_argument("platform", choices=["darwin", "linux"])
+    args = parser.parse_args()
+    if args.command == "stage":
+        stage(args.database)
+    else:
+        scan(args.database, args.scanner, args.output, args.version, args.platform)
+
+
+if __name__ == "__main__":
+    os.umask(0o077)
+    try:
+        main()
+    except Exception as error:
+        print("vulnerability proof failed: " + str(error), file=sys.stderr)
+        sys.exit(1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,46 @@ jobs:
           mkdir -p bin
           GOWORK=off go build -trimpath -ldflags "-X main.version=ci" -o bin/photoscrawl ./cmd/photoscrawl
           test "$(bin/photoscrawl --version)" = "ci"
+
+  vulnerabilities:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    env:
+      GOWORK: "off"
+      GOENV: "off"
+      GOTOOLCHAIN: "local"
+      GOMAXPROCS: "2"
+      GOFLAGS: "-mod=readonly -p=1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.27.1"
+          cache: true
+
+      - name: Verify structured scan evaluator
+        run: python3 .github/scripts/test_vulncheck.py
+
+      - name: Stage public modules, scanner and frozen advisories
+        run: |
+          go version
+          test "$(go env GOVERSION)" = "go1.27.1"
+          go mod download
+          GOBIN="$RUNNER_TEMP/vulntools" go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+          python3 .github/scripts/vulncheck.py stage "$RUNNER_TEMP/vulndb"
+
+      - name: Scan native configuration
+        run: python3 .github/scripts/vulncheck.py scan "$RUNNER_TEMP/vulndb" "$RUNNER_TEMP/vulntools/govulncheck" "$RUNNER_TEMP/vuln-preferred" go1.27.1 darwin
+
+      - name: Retain complete advisory evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: darwin-vulnerability-evidence
+          path: |
+            ${{ runner.temp }}/vulndb
+            ${{ runner.temp }}/vuln-preferred
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Archive safety
+
+- Scope Apple observation replacement to the selected archived library, including valid empty libraries, and reject ambiguous bindings.
+- Preserve asset IDs and full native identifiers across evidence-backed PhotoKit/SQLite fallback changes within one library; reject ambiguous historical duplicates without merging or rekeying them.
+- Read fallback SQLite library metadata from a verified private snapshot without opening the live Photos database.
+- Reject foreign, unsupported, or hardlinked archive databases before writable access changes schema, permissions, or sidecars.
+- Bound photo-card preparation attempts and downloaded originals (256 MiB each, 512 MiB per run); enforce the byte limit while streaming and remove owned temporary originals after preparation.
+
 - Name the SQLite source in snapshot cancellation errors so an aborted Photos snapshot reports which database it was copying.
 
 ## 0.3.2 - 2026-09-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Preserve asset IDs and full native identifiers across evidence-backed PhotoKit/SQLite fallback changes within one library; reject ambiguous historical duplicates without merging or rekeying them.
 - Read fallback SQLite library metadata from a verified private snapshot without opening the live Photos database.
 - Reject foreign, unsupported, or hardlinked archive databases before writable access changes schema, permissions, or sidecars.
+- Refuse orphan SQLite sidecars beside a zero-byte archive before initialization.
 - Bound photo-card preparation attempts and downloaded originals (256 MiB each, 512 MiB per run); enforce the byte limit while streaming and remove owned temporary originals after preparation.
 
 - Name the SQLite source in snapshot cancellation errors so an aborted Photos snapshot reports which database it was copying.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Dependencies
+
+- Update CrawlKit to v0.15.0 while preserving the Go 1.27.0 minimum and preferred Go 1.27.1 toolchain; verify complete frozen-database vulnerability results in macOS CI.
+
 ### Archive safety
 
 - Scope Apple observation replacement to the selected archived library, including valid empty libraries, and reject ambiguous bindings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Read fallback SQLite library metadata from a verified private snapshot without opening the live Photos database.
 - Reject foreign, unsupported, or hardlinked archive databases before writable access changes schema, permissions, or sidecars.
 - Refuse orphan SQLite sidecars beside a zero-byte archive before initialization.
+- Validate the same normalized archive filename SQLite opens when a path contains a symlink followed by `..`.
 - Bound photo-card preparation attempts and downloaded originals (256 MiB each, 512 MiB per run); enforce the byte limit while streaming and remove owned temporary originals after preparation.
 
 - Name the SQLite source in snapshot cancellation errors so an aborted Photos snapshot reports which database it was copying.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Reject foreign, unsupported, or hardlinked archive databases before writable access changes schema, permissions, or sidecars.
 - Refuse orphan SQLite sidecars beside a zero-byte archive before initialization.
 - Validate the same normalized archive filename SQLite opens when a path contains a symlink followed by `..`.
+- Normalize trailing whitespace before archive and library-binding checks, and reject unstable archive filenames before initialization creates directories.
 - Bound photo-card preparation attempts and downloaded originals (256 MiB each, 512 MiB per run); enforce the byte limit while streaming and remove owned temporary originals after preparation.
 
 - Name the SQLite source in snapshot cancellation errors so an aborted Photos snapshot reports which database it was copying.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Archive safety
 
+- Preserve the selected SQLite data during private verification when the resolved source filename ends in whitespace.
 - Scope Apple observation replacement to the selected archived library, including valid empty libraries, and reject ambiguous bindings.
 - Preserve asset IDs and full native identifiers across evidence-backed PhotoKit/SQLite fallback changes within one library; reject ambiguous historical duplicates without merging or rekeying them.
 - Read fallback SQLite library metadata from a verified private snapshot without opening the live Photos database.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ private images, metadata, and model responses under the crawlkit data dir's
 missing originals into the crawlkit cache dir's `originals` subtree; normal
 crawl/classify commands do not force iCloud downloads.
 
+Preparation tries at most three times the requested card limit. Downloaded
+originals are limited to 256 MiB each and 512 MiB per run, streamed into owned
+temporary cache files and removed after preparation, including on failure.
+Existing local originals and older cache files are never deleted by this cleanup.
+The summary includes `assets_attempted`; retained JPEGs and metadata remain in
+the output directory, while temporary original paths are provenance only.
+
 The eval-card summary is written only after its manifest flush and close succeed;
 manifest persistence errors fail the run before the summary is written.
 

--- a/cmd/photoscrawl/export_native_darwin_test.go
+++ b/cmd/photoscrawl/export_native_darwin_test.go
@@ -45,9 +45,9 @@ func TestExportNativeIntegration(t *testing.T) {
 		}
 	}
 	cases := []struct {
-		name, mode, wantError                        string
-		flags                                        []string
-		signal, driver, directory, longName, success bool
+		name, mode, wantError                                   string
+		flags                                                   []string
+		signal, driver, directory, longName, success, cancelAck bool
 	}{
 		{name: "unlimited-default", mode: "slow", success: true},
 		{name: "explicit-unlimited", mode: "slow", flags: []string{"--timeout", "0"}, success: true},
@@ -63,6 +63,10 @@ func TestExportNativeIntegration(t *testing.T) {
 		{name: "invalid-timeout", mode: "success", flags: []string{"--timeout", "-1s"}, wantError: "timeout must not be negative"},
 		{name: "retry-before-late-callback", mode: "retry", driver: true, success: true},
 		{name: "late-authorization-callback", mode: "auth", driver: true},
+		{name: "limited-exact-budget", mode: "limited-exact", driver: true, success: true},
+		{name: "limited-single-chunk-overflow", mode: "limited-over-single", driver: true, cancelAck: true},
+		{name: "limited-cumulative-overflow", mode: "limited-over-chunked", driver: true, cancelAck: true},
+		{name: "limited-cancel-after-partial-write", mode: "limited-cancel", driver: true, cancelAck: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -146,9 +150,19 @@ func TestExportNativeIntegration(t *testing.T) {
 			if _, err := os.Stat(filepath.Join(dir, "loaded")); err != nil {
 				t.Fatal("required PhotoKit fixture was not loaded")
 			}
-			if tc.mode == "stall" || tc.mode == "delayed-id" || tc.mode == "retry" || tc.mode == "write-error" {
+			if tc.cancelAck || tc.mode == "stall" || tc.mode == "delayed-id" || tc.mode == "retry" || tc.mode == "write-error" {
 				if _, err := os.Stat(filepath.Join(dir, "cancelled")); err != nil {
 					t.Fatal("native request was not cancelled")
+				}
+			}
+			if strings.HasPrefix(tc.mode, "limited-") {
+				if _, err := os.Stat(filepath.Join(dir, "streamed")); err != nil {
+					t.Fatal("limited export did not reach the native data callback")
+				}
+				if tc.success {
+					if _, err := os.Stat(filepath.Join(dir, "cancelled")); !os.IsNotExist(err) {
+						t.Fatalf("successful limited export cancellation marker: %v", err)
+					}
 				}
 			}
 			contents, err := os.ReadFile(preserved)

--- a/cmd/photoscrawl/testdata/exportdriver/main.go
+++ b/cmd/photoscrawl/testdata/exportdriver/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/openclaw/photoscrawl/internal/photos"
@@ -18,6 +19,11 @@ func main() {
 		panic("native fixture not loaded")
 	}
 	destination := os.Args[1]
+	mode := os.Getenv("PHOTOSCRAWL_NATIVE_FIXTURE_MODE")
+	if strings.HasPrefix(mode, "limited-") {
+		runLimited(root, destination, mode)
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	if err := photos.ExportOriginalResource(ctx, "synthetic", destination, false); !errors.Is(err, context.DeadlineExceeded) {
@@ -39,4 +45,84 @@ func main() {
 		time.Sleep(5 * time.Millisecond)
 	}
 	fmt.Println("deadline propagated; late callback completed safely")
+}
+
+func runLimited(root, destination, mode string) {
+	var limit int64
+	switch mode {
+	case "limited-exact", "limited-cancel":
+		limit = 18
+	case "limited-over-single", "limited-over-chunked":
+		limit = 17
+	default:
+		panic("unknown limited fixture mode")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		result <- photos.ExportOriginalResourceLimited(ctx, "synthetic", destination, false, limit)
+	}()
+	if mode == "limited-cancel" {
+		waitMarker(root, "partial")
+		staging, err := filepath.Glob(filepath.Join(filepath.Dir(destination), ".photoscrawl-export-*"))
+		if err != nil || len(staging) != 1 {
+			panic(fmt.Sprintf("partial staging files: %v (%v)", staging, err))
+		}
+		partial, err := os.ReadFile(staging[0])
+		if err != nil || string(partial) != "partial" {
+			panic(fmt.Sprintf("partial write: %q (%v)", partial, err))
+		}
+		cancel()
+	}
+	var err error
+	select {
+	case err = <-result:
+	case <-time.After(5 * time.Second):
+		panic("limited export did not return")
+	}
+	switch mode {
+	case "limited-exact":
+		if err != nil {
+			panic(fmt.Sprintf("exact budget: %v", err))
+		}
+	case "limited-over-single", "limited-over-chunked":
+		if err == nil || err.Error() != "original resource exceeds byte limit" {
+			panic(fmt.Sprintf("byte limit error: %v", err))
+		}
+	case "limited-cancel":
+		if !errors.Is(err, context.Canceled) {
+			panic(fmt.Sprintf("cancellation error: %v", err))
+		}
+		contents, readErr := os.ReadFile(destination)
+		staging, globErr := filepath.Glob(filepath.Join(filepath.Dir(destination), ".photoscrawl-export-*"))
+		if readErr != nil || string(contents) != "existing-original" || globErr != nil || len(staging) != 0 {
+			panic("cancelled export did not preserve destination and remove staging before returning")
+		}
+		if _, statErr := os.Stat(filepath.Join(root, "late")); !errors.Is(statErr, os.ErrNotExist) {
+			panic("late callbacks ran before the post-return barrier")
+		}
+		if writeErr := os.WriteFile(filepath.Join(root, "export-returned"), nil, 0600); writeErr != nil {
+			panic(writeErr)
+		}
+		waitMarker(root, "late")
+	}
+	fmt.Printf("limited export %s: expected result; callbacks complete\n", mode)
+}
+
+func waitMarker(root, name string) {
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		_, err := os.Stat(filepath.Join(root, name))
+		if err == nil {
+			return
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			panic(err)
+		}
+		if time.Now().After(deadline) {
+			panic("native fixture marker did not arrive: " + name)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 }

--- a/cmd/photoscrawl/testdata/photokit_fixture.m
+++ b/cmd/photoscrawl/testdata/photokit_fixture.m
@@ -15,6 +15,27 @@ static void mark(NSString *name) {
   NSString *path = [root stringByAppendingPathComponent:name];
   if (![[NSFileManager defaultManager] createFileAtPath:path contents:[NSData data] attributes:nil]) abort();
 }
+static void confirmPartial(NSData *expected) {
+  NSString *directory = [root stringByAppendingPathComponent:@"out"];
+  NSArray *entries = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:directory error:NULL];
+  NSUInteger count = 0;
+  for (NSString *entry in entries) {
+    if (![entry hasPrefix:@".photoscrawl-export-"]) continue;
+    NSData *actual = [NSData dataWithContentsOfFile:[directory stringByAppendingPathComponent:entry]];
+    if (![actual isEqualToData:expected]) abort();
+    count++;
+  }
+  if (count != 1) abort();
+  mark(@"partial");
+}
+static void waitForMarker(NSString *name) {
+  NSString *path = [root stringByAppendingPathComponent:name];
+  NSTimeInterval deadline = NSProcessInfo.processInfo.systemUptime + 5;
+  while (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
+    if (NSProcessInfo.processInfo.systemUptime >= deadline) abort();
+    usleep(5000);
+  }
+}
 static PHAuthorizationStatus authorization(id self, SEL selector, ...) {
   return [mode hasPrefix:@"auth"] ? PHAuthorizationStatusNotDetermined : PHAuthorizationStatusAuthorized;
 }
@@ -51,7 +72,27 @@ static id resources(id self, SEL selector, id asset) { return @[[PCFixtureResour
     }
 
   NSData *bytes = [@"synthetic-original" dataUsingEncoding:NSUTF8StringEncoding];
-  if ([mode isEqual:@"stall"] || [mode isEqual:@"delayed-id"] || ([mode isEqual:@"retry"] && request == 1)) {
+  if ([mode hasPrefix:@"limited-"]) {
+    if (((PHAssetResourceRequestOptions *)options).networkAccessAllowed) abort();
+    if ([mode isEqual:@"limited-cancel"]) {
+      @synchronized(pending) { pending[@(request)] = @[[data copy], [complete copy]]; }
+      NSData *partial = [@"partial" dataUsingEncoding:NSUTF8StringEncoding];
+      data(partial);
+      confirmPartial(partial);
+    } else if ([mode isEqual:@"limited-over-single"]) {
+      data(bytes);
+      complete(nil);
+    } else if ([mode isEqual:@"limited-exact"] || [mode isEqual:@"limited-over-chunked"]) {
+      NSData *first = [bytes subdataWithRange:NSMakeRange(0, 7)];
+      data(first);
+      confirmPartial(first);
+      data([bytes subdataWithRange:NSMakeRange(7, bytes.length - 7)]);
+      complete(nil);
+    } else {
+      abort();
+    }
+    mark(@"streamed");
+  } else if ([mode isEqual:@"stall"] || [mode isEqual:@"delayed-id"] || ([mode isEqual:@"retry"] && request == 1)) {
     @synchronized(pending) { pending[@(request)] = @[[data copy], [complete copy]]; }
     data([@"partial" dataUsingEncoding:NSUTF8StringEncoding]);
     if ([mode isEqual:@"delayed-id"]) usleep(200000);
@@ -85,7 +126,15 @@ static id resources(id self, SEL selector, id asset) { return @[[PCFixtureResour
     complete(nil);
     mark(@"late");
   };
-  if ([mode isEqual:@"retry"]) {
+  if ([mode isEqual:@"limited-cancel"]) {
+    // The Go driver releases this barrier only after the export API returns.
+    dispatch_async(dispatch_get_global_queue(0, 0), ^{
+      @autoreleasepool {
+        waitForMarker(@"export-returned");
+        late();
+      }
+    });
+  } else if ([mode isEqual:@"retry"]) {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 300 * NSEC_PER_MSEC), dispatch_get_global_queue(0, 0), late);
   } else {
     late();

--- a/docs/evals/photo-card-protocol.md
+++ b/docs/evals/photo-card-protocol.md
@@ -35,6 +35,13 @@ local, it asks PhotoKit to download/export the original into a private cache
 under the crawlkit cache dir's `originals` subtree. Normal crawl behavior
 remains read-only/local-first and does not force iCloud downloads.
 
+Preparation attempts are capped at three times `--limit`. New originals are
+streamed with a 256 MiB per-object limit and a 512 MiB run allowance, then removed
+from their owned temporary cache directory after preparation, even on failure.
+Existing Photos package originals and older cache files are not removed.
+`assets_attempted` reports the attempted sample size. Original paths marked
+`photokit_original_export_temporary` are provenance, not retained artifacts.
+
 For each asset, the harness writes a canonical full-resolution JPEG to the
 private eval directory. The JPEG has display-upright pixels and does not copy the
 original EXIF block. Full asset, resource, and ImageIO metadata are written as a

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.27.0
 toolchain go1.27.1
 
 require (
-	github.com/openclaw/crawlkit v0.14.8
+	github.com/openclaw/crawlkit v0.15.0
 	modernc.org/sqlite v1.58.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsRe
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.8 h1:JdmvIcfznzGGDNczACtktebd0ueLWaTrCwW8ZPtm7Fg=
-github.com/openclaw/crawlkit v0.14.8/go.mod h1:7QxbJgGm6ZQAiBXyWSR+U6Eyt8p4pMcC7zjY0h3GKjY=
+github.com/openclaw/crawlkit v0.15.0 h1:KAmdew2UQPZm/gOfqiLw/WhhDY7Y2UZj0EcgQ5s7dl4=
+github.com/openclaw/crawlkit v0.15.0/go.mod h1:JhEsXnoxozd2qp1p4Dw8ZhKzQoYm3WbrlvO0ILVx8cs=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/internal/archive/apple_metadata.go
+++ b/internal/archive/apple_metadata.go
@@ -213,8 +213,8 @@ func loadPhotoMetadataInput(ctx context.Context, db *sql.DB) (photoMetadataImpor
 	}, nil
 }
 
-func writePhotoMetadataImport(ctx context.Context, tx *sql.Tx, input photoMetadataImportInput, assetByUUID map[string]string, importedAt time.Time) (ImportPhotoMetadataResult, map[string]bool, error) {
-	if err := clearImportedPhotoMetadata(ctx, tx); err != nil {
+func writePhotoMetadataImport(ctx context.Context, tx *sql.Tx, input photoMetadataImportInput, assetByUUID appleAssetScope, importedAt time.Time) (ImportPhotoMetadataResult, map[string]bool, error) {
+	if err := clearImportedPhotoMetadata(ctx, tx, assetByUUID.libraryID); err != nil {
 		return ImportPhotoMetadataResult{}, nil, err
 	}
 	result := ImportPhotoMetadataResult{
@@ -226,7 +226,7 @@ func writePhotoMetadataImport(ctx context.Context, tx *sql.Tx, input photoMetada
 	}
 	touched := map[string]bool{}
 	for _, row := range input.rows {
-		assetID, ok := assetByUUID[row.assetUUID]
+		assetID, ok := assetByUUID.byUUID[row.assetUUID]
 		if !ok {
 			result.AssetsUnresolved++
 			continue
@@ -259,17 +259,17 @@ func writePhotoMetadataImport(ctx context.Context, tx *sql.Tx, input photoMetada
 	return result, touched, nil
 }
 
-func clearImportedPhotoMetadata(ctx context.Context, tx *sql.Tx) error {
-	if _, err := tx.ExecContext(ctx, `delete from observation_fts where id in (select id from model_observation where source = ? and model_id = ?)`, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID); err != nil {
+func clearImportedPhotoMetadata(ctx context.Context, tx *sql.Tx, libraryID string) error {
+	if _, err := tx.ExecContext(ctx, `delete from observation_fts where id in (select id from model_observation where source = ? and model_id = ? and asset_id in (select id from asset where source_library_id = ?))`, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID, libraryID); err != nil {
 		return fmt.Errorf("clear Apple photo metadata search rows: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `delete from observation_term where observation_id in (select id from model_observation where source = ? and model_id = ?)`, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID); err != nil {
+	if _, err := tx.ExecContext(ctx, `delete from observation_term where observation_id in (select id from model_observation where source = ? and model_id = ? and asset_id in (select id from asset where source_library_id = ?))`, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID, libraryID); err != nil {
 		return fmt.Errorf("clear Apple photo metadata terms: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `delete from model_observation where source = ? and model_id = ?`, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID); err != nil {
+	if _, err := tx.ExecContext(ctx, `delete from model_observation where source = ? and model_id = ? and asset_id in (select id from asset where source_library_id = ?)`, photosLibraryDBFaceSource, photosLibraryDBMetadataModelID, libraryID); err != nil {
 		return fmt.Errorf("clear Apple photo metadata observations: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `delete from evidence_ref where source = ? and evidence_kind = 'apple_photo_metadata'`, photosLibraryDBFaceSource); err != nil {
+	if _, err := tx.ExecContext(ctx, `delete from evidence_ref where source = ? and evidence_kind = 'apple_photo_metadata' and asset_id in (select id from asset where source_library_id = ?)`, photosLibraryDBFaceSource, libraryID); err != nil {
 		return fmt.Errorf("clear Apple photo metadata evidence: %w", err)
 	}
 	return nil

--- a/internal/archive/apple_scope.go
+++ b/internal/archive/apple_scope.go
@@ -69,9 +69,13 @@ func libraryComparisonPath(path string) (string, error) {
 }
 
 func openAppleArchive(ctx context.Context, path, libraryPath string) (*store.Store, error) {
+	sqlitePath, err := archiveFilename(path)
+	if err != nil {
+		return nil, err
+	}
 	// Check the binding on a private copy before a writable open can migrate or
 	// change permissions. The transaction resolves it again before replacement.
-	private, cleanup, err := photos.CopySQLite(ctx, path, "photoscrawl-library-preflight-")
+	private, cleanup, err := photos.CopySQLite(ctx, sqlitePath, "photoscrawl-library-preflight-")
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +89,7 @@ func openAppleArchive(ctx context.Context, path, libraryPath string) (*store.Sto
 	if bindingErr != nil {
 		return nil, bindingErr
 	}
-	return openArchiveStore(ctx, path)
+	return openArchiveStore(ctx, sqlitePath)
 }
 
 func archiveAssetMap(ctx context.Context, tx *sql.Tx, libraryPath string) (appleAssetScope, error) {

--- a/internal/archive/apple_scope.go
+++ b/internal/archive/apple_scope.go
@@ -1,0 +1,117 @@
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/openclaw/crawlkit/store"
+	"github.com/openclaw/photoscrawl/internal/photos"
+)
+
+type appleAssetScope struct {
+	libraryID string
+	byUUID    map[string]string
+}
+
+type libraryQuerier interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func libraryIdentity(ctx context.Context, db libraryQuerier, requested string) (string, error) {
+	requested, err := libraryComparisonPath(requested)
+	if err != nil {
+		return "", err
+	}
+	rows, err := db.QueryContext(ctx, `select id, library_path from source_library`)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	match := ""
+	for rows.Next() {
+		var id, path string
+		if err := rows.Scan(&id, &path); err != nil {
+			return "", err
+		}
+		path, err = libraryComparisonPath(path)
+		if err != nil {
+			return "", err
+		}
+		if path != requested {
+			continue
+		}
+		if match != "" {
+			return "", errors.New("multiple archived libraries match the requested library")
+		}
+		match = id
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	if match == "" {
+		return "", errors.New("requested library is not in the archive; crawl it before importing Apple observations")
+	}
+	return match, nil
+}
+
+func libraryComparisonPath(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		return resolved, nil
+	}
+	return absolute, nil
+}
+
+func openAppleArchive(ctx context.Context, path, libraryPath string) (*store.Store, error) {
+	// Check the binding on a private copy before a writable open can migrate or
+	// change permissions. The transaction resolves it again before replacement.
+	private, cleanup, err := photos.CopySQLite(ctx, path, "photoscrawl-library-preflight-")
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	db, err := store.OpenReadOnly(ctx, private)
+	if err != nil {
+		return nil, err
+	}
+	_, bindingErr := libraryIdentity(ctx, db.DB(), libraryPath)
+	_ = db.Close()
+	if bindingErr != nil {
+		return nil, bindingErr
+	}
+	return openArchiveStore(ctx, path)
+}
+
+func archiveAssetMap(ctx context.Context, tx *sql.Tx, libraryPath string) (appleAssetScope, error) {
+	libraryID, err := libraryIdentity(ctx, tx, libraryPath)
+	if err != nil {
+		return appleAssetScope{}, err
+	}
+	rows, err := tx.QueryContext(ctx, `select id, local_identifier from asset where source_library_id = ?`, libraryID)
+	if err != nil {
+		return appleAssetScope{}, fmt.Errorf("load archive assets: %w", err)
+	}
+	defer rows.Close()
+	out := appleAssetScope{libraryID: libraryID, byUUID: map[string]string{}}
+	for rows.Next() {
+		var assetID, localIdentifier string
+		if err := rows.Scan(&assetID, &localIdentifier); err != nil {
+			return appleAssetScope{}, err
+		}
+		uuid := normalizeAssetLocalIdentifier(localIdentifier)
+		if uuid == "" {
+			continue
+		}
+		if previous, exists := out.byUUID[uuid]; exists && previous != assetID {
+			return appleAssetScope{}, errors.New("ambiguous asset identifiers in the requested library")
+		}
+		out.byUUID[uuid] = assetID
+	}
+	return out, rows.Err()
+}

--- a/internal/archive/apple_scope_test.go
+++ b/internal/archive/apple_scope_test.go
@@ -1,0 +1,141 @@
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/crawlkit/store"
+)
+
+func TestAppleImportReplacementIsLibraryScoped(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	paths := Paths{DataDir: root, Database: filepath.Join(root, "archive.sqlite")}
+	db, err := openArchiveStore(ctx, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	libraries := []string{filepath.Join(root, "A.photoslibrary"), filepath.Join(root, "B.photoslibrary")}
+	for i, library := range libraries {
+		sourceID := stableID("source_library", library)
+		identifier := "92D69D06-27F0-4831-AEC7-C6F640F075BA/L0/001"
+		if i == 1 {
+			identifier = "92D69D06-27F0-4831-AEC7-C6F640F075BA"
+		}
+		seedAppleAsset(t, db.DB(), sourceID, library, sourceID+"-asset", identifier)
+		createTestPhotosDB(t, filepath.Join(library, "database", "Photos.sqlite"))
+		createTestPSIDB(t, filepath.Join(library, "database", "search", "psi.sqlite"))
+		if _, err := ImportApple(ctx, paths, ImportAppleOptions{LibraryPath: library}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	assertCount(t, db.DB(), `select count(*) from face_observation where source = 'photos_library_db'`, 2)
+	aID, bID := stableID("source_library", libraries[0])+"-asset", stableID("source_library", libraries[1])+"-asset"
+	beforeB := appleRows(t, db.DB(), bID)
+	if _, err := ImportApple(ctx, paths, ImportAppleOptions{LibraryPath: libraries[0]}); err != nil {
+		t.Fatal(err)
+	}
+	assertAppleRows(t, db.DB(), bID, beforeB)
+
+	source, err := sql.Open("sqlite", filepath.Join(libraries[0], "database", "Photos.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	execTestSQL(t, source, `delete from ZDETECTEDFACE; delete from ZASSET; delete from ZEXTENDEDATTRIBUTES; delete from ZCOMPUTEDASSETATTRIBUTES`)
+	_ = source.Close()
+	search, err := sql.Open("sqlite", filepath.Join(libraries[0], "database", "search", "psi.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	execTestSQL(t, search, `delete from ga`)
+	_ = search.Close()
+	if _, err := ImportApple(ctx, paths, ImportAppleOptions{LibraryPath: libraries[0]}); err != nil {
+		t.Fatalf("valid empty library: %v", err)
+	}
+	for table, count := range appleRows(t, db.DB(), aID) {
+		if count != 0 {
+			t.Fatalf("empty library retained %s rows: %d", table, count)
+		}
+	}
+	assertAppleRows(t, db.DB(), bID, beforeB)
+
+	unknown := filepath.Join(root, "Unknown.photoslibrary")
+	createTestPhotosDB(t, filepath.Join(unknown, "database", "Photos.sqlite"))
+	createTestPSIDB(t, filepath.Join(unknown, "database", "search", "psi.sqlite"))
+	if _, err := ImportApple(ctx, paths, ImportAppleOptions{LibraryPath: unknown}); err == nil {
+		t.Fatal("unknown library accepted")
+	}
+	assertAppleRows(t, db.DB(), bID, beforeB)
+
+	// A late metadata failure must roll back earlier face/search replacement.
+	execTestSQL(t, db.DB(), `create trigger fail_metadata before insert on model_observation begin select raise(abort, 'synthetic metadata failure'); end`)
+	if _, err := ImportApple(ctx, paths, ImportAppleOptions{LibraryPath: libraries[1]}); err == nil {
+		t.Fatal("injected late failure accepted")
+	}
+	assertAppleRows(t, db.DB(), bID, beforeB)
+}
+
+func TestAppleScopeRejectsAmbiguousAssetsAndAllowsZeroAssets(t *testing.T) {
+	ctx := context.Background()
+	db, err := openArchiveStore(ctx, filepath.Join(t.TempDir(), "archive.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	library := filepath.Join(t.TempDir(), "Library.photoslibrary")
+	seedAppleAsset(t, db.DB(), "library", library, "one", "same/L0/001")
+	execTestSQL(t, db.DB(), `insert into asset select 'two', 'same', media_type, media_subtypes, creation_date, modification_date,
+added_date, timezone_name, width, height, duration_seconds, favorite, hidden, burst_identifier, represents_burst,
+source_library_id, metadata_json, deleted_at, deletion_source, deletion_reason from asset where id='one'`)
+	tx, err := db.DB().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := archiveAssetMap(ctx, tx, library); err == nil {
+		t.Fatal("ambiguous normalized identifiers accepted")
+	}
+	_ = tx.Rollback()
+	execTestSQL(t, db.DB(), `delete from asset`)
+	tx, err = db.DB().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	scope, err := archiveAssetMap(ctx, tx, library)
+	if err != nil || scope.libraryID != "library" || len(scope.byUUID) != 0 {
+		t.Fatalf("bound empty scope = %#v, %v", scope, err)
+	}
+}
+
+func seedAppleAsset(t *testing.T, db *sql.DB, sourceID, library, assetID, identifier string) {
+	t.Helper()
+	execTestSQL(t, db, `insert into source_library values(?, ?, '', '', '', '{}')`, sourceID, library)
+	execTestSQL(t, db, `insert into asset(id, local_identifier, media_type, media_subtypes, creation_date, modification_date,
+added_date, timezone_name, width, height, duration_seconds, favorite, hidden, burst_identifier, represents_burst, source_library_id, metadata_json)
+values(?, ?, 'image', '', '', '', '', '', 100, 100, 0, 0, 0, '', 0, ?, '{}')`, assetID, identifier, sourceID)
+}
+
+func appleRows(t *testing.T, db *sql.DB, assetID string) map[string]int {
+	t.Helper()
+	result := map[string]int{}
+	for _, table := range []string{"face_observation", "visual_observation", "model_observation", "observation_fts", "observation_term", "evidence_ref"} {
+		var count int
+		if err := db.QueryRow(`select count(*) from `+store.QuoteIdent(table)+` where asset_id = ?`, assetID).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		result[table] = count
+	}
+	return result
+}
+
+func assertAppleRows(t *testing.T, db *sql.DB, assetID string, want map[string]int) {
+	t.Helper()
+	for table, count := range appleRows(t, db, assetID) {
+		if count != want[table] {
+			t.Fatalf("%s rows = %d, want %d", table, count, want[table])
+		}
+	}
+}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -17,10 +17,14 @@ type InitResult struct {
 }
 
 func Init(ctx context.Context, paths Paths) (InitResult, error) {
-	if err := os.MkdirAll(filepath.Dir(paths.Database), 0o700); err != nil {
+	sqlitePath, err := archiveFilename(paths.Database)
+	if err != nil {
 		return InitResult{}, err
 	}
-	db, err := openArchiveStore(ctx, paths.Database)
+	if err := os.MkdirAll(filepath.Dir(sqlitePath), 0o700); err != nil {
+		return InitResult{}, err
+	}
+	db, err := openArchiveStore(ctx, sqlitePath)
 	if err != nil {
 		return InitResult{}, err
 	}

--- a/internal/archive/archive_path.go
+++ b/internal/archive/archive_path.go
@@ -1,0 +1,20 @@
+package archive
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+)
+
+func archiveFilename(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	// Match CrawlKit's trim after Abs without changing literal source paths.
+	filename := strings.TrimSpace(absolute)
+	if filepath.Clean(filename) != filename {
+		return "", errors.New("archive filename becomes unstable after trimming whitespace")
+	}
+	return filename, nil
+}

--- a/internal/archive/archive_path_test.go
+++ b/internal/archive/archive_path_test.go
@@ -1,0 +1,270 @@
+package archive
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/openclaw/crawlkit/store"
+)
+
+func TestArchiveFilenameWhitespace(t *testing.T) {
+	t.Chdir(t.TempDir())
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, raw := range []string{"archive.db ", "archive.db\t", "archive.db\u00a0", " archive.db "} {
+		got, err := archiveFilename(raw)
+		want := filepath.Join(root, "archive.db")
+		if raw[0] == ' ' {
+			want = filepath.Join(root, " archive.db")
+		}
+		if err != nil || got != want {
+			t.Fatalf("filename %q = %q, %v; want %q", raw, got, err, want)
+		}
+		if again, err := archiveFilename(got); err != nil || again != got {
+			t.Fatalf("filename is not stable: %q, %v", again, err)
+		}
+	}
+}
+
+func TestArchiveWhitespaceRefusesUnstableFilenameBeforeMkdir(t *testing.T) {
+	for _, final := range []string{". ", ".. ", " \t"} {
+		for _, operation := range []string{"writable", "readonly", "apple", "init"} {
+			t.Run(final+"/"+operation, func(t *testing.T) {
+				parent := filepath.Join(t.TempDir(), "new-parent")
+				raw := parent + string(filepath.Separator) + final
+				if err := openWhitespaceArchive(t, operation, raw, "synthetic.photoslibrary"); err == nil {
+					t.Fatal("unstable archive filename accepted")
+				}
+				if _, err := os.Stat(parent); !os.IsNotExist(err) {
+					t.Fatalf("unstable filename created a parent: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestArchiveWhitespaceRejectsForeignTarget(t *testing.T) {
+	for _, journal := range []string{"DELETE", "WAL"} {
+		for _, suffix := range []string{"", " ", "\t", "\u00a0"} {
+			for _, decoy := range []bool{false, true} {
+				if suffix == "" && decoy {
+					continue
+				}
+				for _, operation := range []string{"writable", "readonly", "apple", "init"} {
+					name := journal + "/" + suffix + "/" + map[bool]string{false: "absent", true: "decoy"}[decoy] + "/" + operation
+					t.Run(name, func(t *testing.T) {
+						root := t.TempDir()
+						target := filepath.Join(root, "foreign.db")
+						library := filepath.Join(root, "Synthetic.photoslibrary")
+						db := createWhitespaceForeignFixture(t, target, journal)
+						defer db.Close()
+						raw := target + suffix
+						if decoy {
+							createWhitespaceArchiveFixture(t, raw, library)
+						}
+						before, decoyBefore := pathFixtureFiles(t, target), pathFixtureFiles(t, raw)
+						if err := openWhitespaceArchive(t, operation, raw, library); err == nil {
+							t.Fatal("foreign effective filename accepted")
+						}
+						if operation == "readonly" && journal == "WAL" {
+							assertReadonlyWALTarget(t, target, before)
+						} else {
+							assertWhitespaceFiles(t, target, before)
+						}
+						if raw != target {
+							assertWhitespaceFiles(t, raw, decoyBefore)
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestAppleArchiveWhitespaceChecksEffectiveBinding(t *testing.T) {
+	for _, suffix := range []string{" ", "\t", "\u00a0"} {
+		t.Run(suffix, func(t *testing.T) {
+			root := t.TempDir()
+			target := filepath.Join(root, "archive.db")
+			otherLibrary := filepath.Join(root, "Other.photoslibrary")
+			requestedLibrary := filepath.Join(root, "Requested.photoslibrary")
+			createWhitespaceArchiveFixture(t, target, otherLibrary)
+			raw := target + suffix
+			createWhitespaceArchiveFixture(t, raw, requestedLibrary)
+			before, decoyBefore := pathFixtureFiles(t, target), pathFixtureFiles(t, raw)
+			if err := openWhitespaceArchive(t, "apple", raw, requestedLibrary); err == nil {
+				t.Fatal("decoy binding authorized a different effective archive")
+			}
+			assertWhitespaceFiles(t, target, before)
+			assertWhitespaceFiles(t, raw, decoyBefore)
+		})
+	}
+}
+
+func TestArchiveWhitespacePositiveOpen(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "archive.db")
+	library := filepath.Join(root, "Synthetic.photoslibrary")
+	createWhitespaceArchiveFixture(t, target, library)
+	for _, raw := range []string{target + " ", target, target + "\t", target + "\u00a0"} {
+		for _, operation := range []string{"writable", "readonly", "apple", "init"} {
+			if err := openWhitespaceArchive(t, operation, raw, library); err != nil {
+				t.Fatalf("%s through %q: %v", operation, raw, err)
+			}
+		}
+		if raw != target {
+			if _, err := os.Stat(raw); !os.IsNotExist(err) {
+				t.Fatalf("literal whitespace archive unexpectedly created: %v", err)
+			}
+		}
+	}
+}
+
+func TestInitWhitespaceCreatesEffectiveFilenameAndKeepsDisplay(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "new-parent")
+	target := filepath.Join(parent, "archive.db")
+	if err := openWhitespaceArchive(t, "init", target+" ", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(target + " "); !os.IsNotExist(err) {
+		t.Fatalf("literal whitespace archive unexpectedly created: %v", err)
+	}
+}
+
+func openWhitespaceArchive(t *testing.T, operation, path, library string) error {
+	t.Helper()
+	ctx := context.Background()
+	if operation == "init" {
+		result, err := Init(ctx, Paths{Database: path})
+		if err == nil && result.Database != path {
+			t.Fatalf("Init changed the display spelling: %q", result.Database)
+		}
+		return err
+	}
+	var db *store.Store
+	var err error
+	switch operation {
+	case "writable":
+		db, err = openArchiveStore(ctx, path)
+	case "readonly":
+		db, err = openArchiveReadOnly(ctx, path)
+	case "apple":
+		db, err = openAppleArchive(ctx, path, library)
+	default:
+		t.Fatalf("unknown test operation: %s", operation)
+	}
+	if db != nil {
+		defer db.Close()
+		if err == nil {
+			want, pathErr := archiveFilename(path)
+			if pathErr != nil || db.Path() != want {
+				t.Fatalf("wrong archive filename: %q, want %q, %v", db.Path(), want, pathErr)
+			}
+		}
+	}
+	return err
+}
+
+func createWhitespaceForeignFixture(t *testing.T, path, journal string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	execTestSQL(t, db, "pragma journal_mode="+journal)
+	execTestSQL(t, db, "create table foreign_marker(value text)")
+	execTestSQL(t, db, "insert into foreign_marker values ('synthetic-only')")
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func createWhitespaceArchiveFixture(t *testing.T, path, library string) {
+	t.Helper()
+	seed := filepath.Join(t.TempDir(), "seed.db")
+	db, err := openArchiveStore(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	execTestSQL(t, db.DB(), `insert into source_library values('synthetic-library', ?, '', '', '', '{}')`, library)
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Seed through an ordinary filename, then retain the literal decoy spelling.
+	if err := os.Rename(seed, path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertWhitespaceFiles(t *testing.T, path string, before map[string]pathFixtureFile) {
+	t.Helper()
+	after := pathFixtureFiles(t, path)
+	if reflect.DeepEqual(before, after) {
+		return
+	}
+	for suffix, want := range before {
+		got, ok := after[suffix]
+		if !ok {
+			t.Errorf("fixture sidecar %q disappeared", suffix)
+			continue
+		}
+		if want.mode != got.mode || !bytes.Equal(want.data, got.data) {
+			offset := 0
+			for offset < len(want.data) && offset < len(got.data) && want.data[offset] == got.data[offset] {
+				offset++
+			}
+			t.Errorf("fixture %q changed: mode %v -> %v, bytes %d -> %d, first difference %d",
+				suffix, want.mode, got.mode, len(want.data), len(got.data), offset)
+		}
+	}
+	for suffix := range after {
+		if _, ok := before[suffix]; !ok {
+			t.Errorf("fixture sidecar %q appeared", suffix)
+		}
+	}
+}
+
+func assertReadonlyWALTarget(t *testing.T, path string, before map[string]pathFixtureFile) {
+	t.Helper()
+	after := pathFixtureFiles(t, path)
+	if len(before) != len(after) {
+		t.Errorf("read-only target sidecar inventory changed: %d -> %d", len(before), len(after))
+	}
+	for suffix, want := range before {
+		got, ok := after[suffix]
+		if !ok {
+			t.Errorf("read-only target file %q disappeared", suffix)
+			continue
+		}
+		if want.mode != got.mode || len(want.data) != len(got.data) {
+			t.Errorf("read-only target %q changed: mode %v -> %v, bytes %d -> %d",
+				suffix, want.mode, got.mode, len(want.data), len(got.data))
+			continue
+		}
+		for offset, value := range want.data {
+			// Direct SQLite readers may update WAL reader-mark slots 1-4.
+			if suffix == "-shm" && offset >= 104 && offset < 120 {
+				continue
+			}
+			if value != got.data[offset] {
+				t.Errorf("read-only target %q changed outside reader marks at offset %d", suffix, offset)
+				break
+			}
+		}
+	}
+}

--- a/internal/archive/asset_identity.go
+++ b/internal/archive/asset_identity.go
@@ -1,0 +1,193 @@
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/openclaw/photoscrawl/internal/photos"
+)
+
+type assetIdentityCandidate struct {
+	id, identifier string
+	seen, trusted  bool
+	conflicting    bool
+}
+
+type assetIdentityResolver struct {
+	sourceID string
+	exact    map[string]*assetIdentityCandidate
+	byUUID   map[string][]*assetIdentityCandidate
+}
+
+func newAssetIdentityResolver(ctx context.Context, tx *sql.Tx, sourceID string) (*assetIdentityResolver, error) {
+	r := &assetIdentityResolver{
+		sourceID: sourceID, exact: map[string]*assetIdentityCandidate{},
+		byUUID: map[string][]*assetIdentityCandidate{},
+	}
+	byID := map[string]*assetIdentityCandidate{}
+	rows, err := tx.QueryContext(ctx, `
+select a.id, a.local_identifier,
+       coalesce(first.source_library_id = a.source_library_id
+                and last.source_library_id = a.source_library_id, 0)
+from asset a
+left join crawl_seen_asset seen on seen.asset_id = a.id and seen.source_library_id = a.source_library_id
+left join crawl_snapshot first on first.id = seen.first_seen_snapshot_id
+left join crawl_snapshot last on last.id = seen.last_seen_snapshot_id
+where a.source_library_id = ?`, sourceID)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		candidate := &assetIdentityCandidate{}
+		if err := rows.Scan(&candidate.id, &candidate.identifier, &candidate.seen); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		byID[candidate.id] = candidate
+		r.add(candidate)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Evidence retains each provider's observed identifier across alternation.
+	// Latest asset/library metadata alone cannot establish this relationship.
+	rows, err = tx.QueryContext(ctx, `
+select e.asset_id, e.source, e.pointer, e.evidence_kind
+from evidence_ref e join asset a on a.id = e.asset_id
+where a.source_library_id = ? and e.evidence_kind in ('asset_metadata', 'asset_tombstone')
+  and exists (select 1 from crawl_snapshot s
+              where s.source_library_id = a.source_library_id and s.provider = e.source)`, sourceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var assetID, provider, pointer, kind string
+		if err := rows.Scan(&assetID, &provider, &pointer, &kind); err != nil {
+			return nil, err
+		}
+		candidate := byID[assetID]
+		key, canonicalProvider := recognizedAssetIdentifier(candidate.identifier)
+		if key == "" || (provider != "photokit" && provider != "photos_sqlite_snapshot") {
+			continue
+		}
+		observed := strings.TrimPrefix(pointer, "asset:")
+		if kind == "asset_tombstone" {
+			observed, _, _ = strings.Cut(observed, "/tombstone:")
+		}
+		observedKey, observedProvider := recognizedAssetIdentifier(observed)
+		if !strings.HasPrefix(pointer, "asset:") || observedKey != key || observedProvider != provider {
+			candidate.conflicting = true
+			continue
+		}
+		if candidate.seen && provider == canonicalProvider && observed == candidate.identifier {
+			candidate.trusted = true
+		}
+	}
+	return r, rows.Err()
+}
+
+func (r *assetIdentityResolver) add(candidate *assetIdentityCandidate) {
+	r.exact[candidate.identifier] = candidate
+	if key, _ := recognizedAssetIdentifier(candidate.identifier); key != "" {
+		r.byUUID[key] = append(r.byUUID[key], candidate)
+	}
+}
+
+func (r *assetIdentityResolver) resolve(provider string, asset photos.Asset) (string, string, error) {
+	observed := asset.LocalIdentifier
+	key, shapeProvider := recognizedAssetIdentifier(observed)
+	if key == "" || shapeProvider != provider {
+		if exact := r.exact[observed]; exact != nil {
+			return exact.id, exact.identifier, nil
+		}
+		return stableID("asset", r.sourceID, observed), observed, nil
+	}
+	if provider == "photokit" && asset.Metadata["photokit_local_identifier"] != observed {
+		return "", "", errors.New("PhotoKit asset identity lacks matching native identifier evidence")
+	}
+	if provider == "photos_sqlite_snapshot" && asset.Metadata["schema_source"] != "ZASSET" {
+		return "", "", errors.New("SQLite asset identity lacks ZASSET provider evidence")
+	}
+	candidates := r.byUUID[key]
+	// Check the entire recognized candidate set before returning an exact match:
+	// legacy full-ID plus bare-UUID duplicates require rollback, never a winner.
+	if len(candidates) > 1 {
+		return "", "", fmt.Errorf("ambiguous asset identity in this library for %q", observed)
+	}
+	if len(candidates) == 0 {
+		return stableID("asset", r.sourceID, observed), observed, nil
+	}
+	candidate := candidates[0]
+	if candidate.conflicting {
+		return "", "", fmt.Errorf("conflicting provider evidence for asset %q", observed)
+	}
+	if candidate.identifier == observed {
+		return candidate.id, candidate.identifier, nil
+	}
+	_, previousProvider := recognizedAssetIdentifier(candidate.identifier)
+	if !candidate.trusted || previousProvider == provider {
+		return "", "", fmt.Errorf("asset identity lacks unambiguous cross-provider evidence for %q", observed)
+	}
+	canonical := candidate.identifier
+	if provider == "photokit" {
+		canonical = observed
+	}
+	return candidate.id, canonical, nil
+}
+
+func (r *assetIdentityResolver) remember(id, canonical, provider string, observed photos.Asset) {
+	key, _ := recognizedAssetIdentifier(canonical)
+	for _, candidate := range r.byUUID[key] {
+		if candidate.id != id {
+			continue
+		}
+		delete(r.exact, candidate.identifier)
+		candidate.identifier = canonical
+		candidate.seen = true
+		if _, canonicalProvider := recognizedAssetIdentifier(canonical); canonicalProvider == provider {
+			candidate.trusted = true
+		}
+		r.exact[canonical] = candidate
+		return
+	}
+	observedKey, observedProvider := recognizedAssetIdentifier(observed.LocalIdentifier)
+	r.add(&assetIdentityCandidate{
+		id: id, identifier: canonical, seen: true,
+		trusted: key != "" && observedKey == key && observedProvider == provider,
+	})
+}
+
+// Only the UUID and native tail present in supported provider fixtures are
+// related. Other identifiers, including arbitrary slash-bearing values, are opaque.
+func recognizedAssetIdentifier(identifier string) (string, string) {
+	provider := "photos_sqlite_snapshot"
+	uuid := identifier
+	if strings.HasSuffix(identifier, "/L0/001") {
+		provider = "photokit"
+		uuid = strings.TrimSuffix(identifier, "/L0/001")
+	}
+	if len(uuid) != 36 {
+		return "", ""
+	}
+	for i := 0; i < len(uuid); i++ {
+		switch i {
+		case 8, 13, 18, 23:
+			if uuid[i] != '-' {
+				return "", ""
+			}
+		default:
+			b := uuid[i]
+			if !(b >= '0' && b <= '9' || b >= 'a' && b <= 'f' || b >= 'A' && b <= 'F') {
+				return "", ""
+			}
+		}
+	}
+	return strings.ToLower(uuid), provider
+}

--- a/internal/archive/asset_identity_test.go
+++ b/internal/archive/asset_identity_test.go
@@ -1,0 +1,292 @@
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/photoscrawl/internal/photos"
+)
+
+const identityFixtureUUID = "92D69D06-27F0-4831-AEC7-C6F640F075BA"
+
+func identityFixtureAsset(provider, identifier string) photos.Asset {
+	metadata := map[string]any{"schema_source": "ZASSET"}
+	if provider == "photokit" {
+		metadata = map[string]any{"photokit_local_identifier": identifier}
+	}
+	return photos.Asset{
+		LocalIdentifier: identifier, MediaType: "image", Metadata: metadata,
+		Resources: []photos.Resource{{SourceIdentifier: "synthetic-original", Type: "photo", OriginalFilename: "synthetic.jpg"}},
+	}
+}
+
+func identityFixtureCrawl(t *testing.T, paths Paths, library, provider string, sequence int, assets ...photos.Asset) (CrawlResult, error) {
+	t.Helper()
+	return Crawl(context.Background(), paths, CrawlOptions{
+		LibraryPath: library,
+		Provider:    fakeProvider{snapshot: photos.LibrarySnapshot{Provider: provider, Assets: assets}},
+		Now:         fixedClock(fmt.Sprintf("2026-09-08T12:00:%02dZ", sequence)),
+	})
+}
+
+func TestCrawlIdentityPreservesReferencesAcrossProviderCycles(t *testing.T) {
+	for _, first := range []string{"photokit", "photos_sqlite_snapshot"} {
+		t.Run(first, func(t *testing.T) {
+			paths := testPaths(t)
+			library := filepath.Join(t.TempDir(), "Synthetic.photoslibrary")
+			if err := mkdirLibrary(library); err != nil {
+				t.Fatal(err)
+			}
+			second := "photokit"
+			if first == second {
+				second = "photos_sqlite_snapshot"
+			}
+			var retainedID, resourceID, queueID, evidenceID, retainedFirstSnapshot string
+			for i, provider := range []string{first, second, first, second, first} {
+				identifier := identityFixtureUUID
+				if provider == "photokit" {
+					identifier += "/L0/001"
+				}
+				asset := identityFixtureAsset(provider, identifier)
+				result, err := identityFixtureCrawl(t, paths, library, provider, i, asset)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if result.PreviouslySeenMissing != 0 || (i > 0 && result.AssetsNew != 0) {
+					t.Fatalf("provider switch duplicated/missed asset: %#v", result)
+				}
+				db := identityFixtureDB(t, paths)
+				var id, canonical, fingerprint, firstSnapshot string
+				if err := db.QueryRow(`select a.id, a.local_identifier, seen.source_fingerprint, seen.first_seen_snapshot_id
+from asset a join crawl_seen_asset seen on seen.asset_id=a.id`).Scan(&id, &canonical, &fingerprint, &firstSnapshot); err != nil {
+					t.Fatal(err)
+				}
+				wantFingerprint, err := assetFingerprint(asset)
+				if err != nil || fingerprint != wantFingerprint {
+					t.Fatalf("fingerprint must describe observed provider value, not retained canonical ID: %v", err)
+				}
+				if i == 0 {
+					retainedID = id
+					retainedFirstSnapshot = firstSnapshot
+					if err := db.QueryRow("select id from asset_resource").Scan(&resourceID); err != nil {
+						t.Fatal(err)
+					}
+					if err := db.QueryRow("select id from classification_queue").Scan(&queueID); err != nil {
+						t.Fatal(err)
+					}
+					if err := db.QueryRow("select id from evidence_ref where evidence_kind='asset_metadata'").Scan(&evidenceID); err != nil {
+						t.Fatal(err)
+					}
+					if _, err := db.Exec(`insert into text_observation values
+('retained-observation', ?, 'synthetic observation', 1, '{}', 'en', 'synthetic', ?)`, id, evidenceID); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if id != retainedID || firstSnapshot != retainedFirstSnapshot || (i > 0 && canonical != identityFixtureUUID+"/L0/001") {
+					t.Fatalf("identity changed: id=%s canonical=%s", id, canonical)
+				}
+				assertCount(t, db, "select count(*) from asset", 1)
+				assertCount(t, db, "select count(*) from classification_queue where id='"+queueID+"'", 1)
+				assertCount(t, db, "select count(*) from asset_resource where id='"+resourceID+"' and asset_id='"+retainedID+"'", 1)
+				assertCount(t, db, "select count(*) from evidence_ref where id='"+evidenceID+"' and asset_id='"+retainedID+"'", 1)
+				assertCount(t, db, "select count(*) from text_observation where id='retained-observation' and asset_id='"+retainedID+"' and evidence_id='"+evidenceID+"'", 1)
+				assertCount(t, db, "select count(*) from evidence_ref where evidence_kind='asset_metadata' and source='"+provider+"' and pointer='asset:"+identifier+"'", 1)
+				db.Close()
+			}
+		})
+	}
+}
+
+func TestCrawlIdentityAmbiguityRollsBackEvenWithExactCandidate(t *testing.T) {
+	paths := testPaths(t)
+	library := filepath.Join(t.TempDir(), "Synthetic.photoslibrary")
+	if err := mkdirLibrary(library); err != nil {
+		t.Fatal(err)
+	}
+	full := identityFixtureAsset("photokit", identityFixtureUUID+"/L0/001")
+	if _, err := identityFixtureCrawl(t, paths, library, "photokit", 0, full); err != nil {
+		t.Fatal(err)
+	}
+	// Seed the historical duplicate with the old SQL contract, not with the
+	// repaired resolver, preserving its independent ID, seen row and queue.
+	db := identityFixtureDB(t, paths)
+	var sourceID, snapshotID string
+	if err := db.QueryRow("select id, snapshot_path from source_library").Scan(&sourceID, &snapshotID); err != nil {
+		t.Fatal(err)
+	}
+	snapshotID = strings.TrimPrefix(snapshotID, "sqlite:crawl_snapshot/")
+	duplicateID := stableID("asset", sourceID, identityFixtureUUID)
+	if _, err := db.Exec(`insert into asset(id,local_identifier,media_type,media_subtypes,creation_date,modification_date,added_date,timezone_name,width,height,duration_seconds,favorite,hidden,burst_identifier,represents_burst,source_library_id,metadata_json)
+select ?,?,'image','','','','','',0,0,0,0,0,'',0,source_library_id,'{}' from asset limit 1`, duplicateID, identityFixtureUUID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into crawl_snapshot
+select 'legacy-sqlite', source_library_id, started_at, completed_at, 'photos_sqlite_snapshot',
+asset_count, resource_count, album_membership_count, location_count, metadata_json
+from crawl_snapshot where id = ?;
+insert into crawl_seen_asset values (?, ?, 'legacy-sqlite', 'legacy-sqlite', 'legacy-fingerprint', '2026-09-08T12:00:00Z');
+insert into evidence_ref values ('legacy-evidence', ?, 'asset_metadata', 'photos_sqlite_snapshot', ?, '{}');
+insert into classification_queue values ('legacy-queue', ?, ?, 'pending', 'metadata_ingested', 0, '2026-09-08T12:00:00Z')`,
+		snapshotID, sourceID, duplicateID, duplicateID, "asset:"+identityFixtureUUID, duplicateID, sourceID); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+	for i, provider := range []string{"photokit", "photos_sqlite_snapshot"} {
+		identifier := identityFixtureUUID
+		if provider == "photokit" {
+			identifier += "/L0/001"
+		}
+		before := identityFixtureState(t, paths)
+		_, err := identityFixtureCrawl(t, paths, library, provider, i+1, identityFixtureAsset(provider, identifier))
+		if err == nil || !strings.Contains(err.Error(), "ambiguous asset identity") {
+			t.Fatalf("exact+alternate ambiguity = %v", err)
+		}
+		if after := identityFixtureState(t, paths); after != before {
+			t.Fatal("ambiguous crawl changed archive state")
+		}
+	}
+}
+
+func TestCrawlIdentityRequiresDurableProviderEvidence(t *testing.T) {
+	for _, corruption := range []string{"missing-evidence", "missing-seen", "conflicting-evidence", "wrong-library-seen", "incoming-missing", "incoming-conflicting"} {
+		t.Run(corruption, func(t *testing.T) {
+			paths := testPaths(t)
+			library := filepath.Join(t.TempDir(), "Synthetic.photoslibrary")
+			if err := mkdirLibrary(library); err != nil {
+				t.Fatal(err)
+			}
+			asset := identityFixtureAsset("photokit", identityFixtureUUID+"/L0/001")
+			if _, err := identityFixtureCrawl(t, paths, library, "photokit", 0, asset); err != nil {
+				t.Fatal(err)
+			}
+			db := identityFixtureDB(t, paths)
+			statement := ""
+			switch corruption {
+			case "missing-evidence":
+				statement = "delete from evidence_ref where evidence_kind='asset_metadata'"
+			case "missing-seen":
+				statement = "delete from crawl_seen_asset"
+			case "conflicting-evidence":
+				statement = "update evidence_ref set pointer='asset:AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE/L0/001' where evidence_kind='asset_metadata'"
+			case "wrong-library-seen":
+				statement = "update crawl_snapshot set source_library_id='unrelated-library'"
+			}
+			if statement != "" {
+				if _, err := db.Exec(statement); err != nil {
+					t.Fatal(err)
+				}
+			}
+			db.Close()
+			incoming := identityFixtureAsset("photos_sqlite_snapshot", identityFixtureUUID)
+			if corruption == "incoming-missing" {
+				incoming.Metadata = nil
+			}
+			if corruption == "incoming-conflicting" {
+				incoming.Metadata["schema_source"] = "unrelated"
+			}
+			before := identityFixtureState(t, paths)
+			if _, err := identityFixtureCrawl(t, paths, library, "photos_sqlite_snapshot", 1, incoming); err == nil {
+				t.Fatal("unproved relationship accepted")
+			}
+			if after := identityFixtureState(t, paths); after != before {
+				t.Fatal("unproved relationship changed archive state")
+			}
+		})
+	}
+}
+
+func TestCrawlIdentityKeepsOpaqueAndOtherLibraryAssetsSeparate(t *testing.T) {
+	paths := testPaths(t)
+	first, second := filepath.Join(t.TempDir(), "First.photoslibrary"), filepath.Join(t.TempDir(), "Second.photoslibrary")
+	for _, path := range []string{first, second} {
+		if err := mkdirLibrary(path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i, identifier := range []string{"opaque/a", "opaque", identityFixtureUUID + "/unsupported/tail"} {
+		if _, err := identityFixtureCrawl(t, paths, first, "photokit", i, identityFixtureAsset("photokit", identifier)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := identityFixtureCrawl(t, paths, first, "photokit", 4, identityFixtureAsset("photokit", identityFixtureUUID+"/L0/001")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := identityFixtureCrawl(t, paths, second, "photos_sqlite_snapshot", 5, identityFixtureAsset("photos_sqlite_snapshot", identityFixtureUUID)); err != nil {
+		t.Fatal(err)
+	}
+	db := identityFixtureDB(t, paths)
+	assertCount(t, db, "select count(*) from asset", 5)
+	db.Close()
+	// Exact cross-library uniqueness remains the existing constraint, separate
+	// from same-library provider resolution; it cannot repoint the first row.
+	before := identityFixtureState(t, paths)
+	_, err := identityFixtureCrawl(t, paths, first, "photos_sqlite_snapshot", 6,
+		identityFixtureAsset("photos_sqlite_snapshot", identityFixtureUUID))
+	if err != nil {
+		t.Fatal("same-library full ID should remain canonical:", err)
+	}
+	after := identityFixtureState(t, paths)
+	if after == before {
+		t.Fatal("valid same-library fallback was blanket-disabled")
+	}
+	third := filepath.Join(t.TempDir(), "Third.photoslibrary")
+	if err := mkdirLibrary(third); err != nil {
+		t.Fatal(err)
+	}
+	before = identityFixtureState(t, paths)
+	_, err = identityFixtureCrawl(t, paths, third, "photos_sqlite_snapshot", 7, identityFixtureAsset("photos_sqlite_snapshot", identityFixtureUUID))
+	if err == nil || !strings.Contains(err.Error(), "UNIQUE") {
+		t.Fatalf("separate global uniqueness behavior changed: %v", err)
+	}
+	if identityFixtureState(t, paths) != before {
+		t.Fatal("cross-library conflict was not rolled back")
+	}
+}
+
+func identityFixtureDB(t *testing.T, paths Paths) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func identityFixtureState(t *testing.T, paths Paths) string {
+	t.Helper()
+	db := identityFixtureDB(t, paths)
+	defer db.Close()
+	var state strings.Builder
+	for _, table := range []string{"asset", "source_library", "crawl_snapshot", "crawl_seen_asset", "asset_resource", "evidence_ref", "text_observation", "classification_queue", "sync_state"} {
+		rows, err := db.Query("select * from " + table + " order by 1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		columns, err := rows.Columns()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for rows.Next() {
+			values, pointers := make([]any, len(columns)), make([]any, len(columns))
+			for i := range values {
+				pointers[i] = &values[i]
+			}
+			if err := rows.Scan(pointers...); err != nil {
+				t.Fatal(err)
+			}
+			fmt.Fprintf(&state, "%s:%#v\n", table, values)
+		}
+		if err := rows.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return state.String()
+}

--- a/internal/archive/crawl.go
+++ b/internal/archive/crawl.go
@@ -156,6 +156,10 @@ values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	}
 	defer stmts.close()
 	c.stmts = stmts
+	identities, err := newAssetIdentityResolver(ctx, tx, sourceID)
+	if err != nil {
+		return fmt.Errorf("load asset identities: %w", err)
+	}
 
 	for _, asset := range c.snapshot.Assets {
 		if strings.TrimSpace(asset.LocalIdentifier) == "" {
@@ -165,7 +169,10 @@ values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		if err != nil {
 			return err
 		}
-		assetID := stableID("asset", sourceID, asset.LocalIdentifier)
+		assetID, canonicalIdentifier, err := identities.resolve(c.snapshot.Provider, asset)
+		if err != nil {
+			return err
+		}
 		fingerprint, err := assetFingerprint(asset)
 		if err != nil {
 			return err
@@ -189,9 +196,10 @@ values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			c.result.AssetsRestored++
 		}
 		needsClassification := !seenBefore || previousFingerprint != fingerprint || previouslyDeleted
-		if err := c.upsertAsset(ctx, tx, sourceID, snapshotID, assetID, fingerprint, deleted, needsClassification, asset); err != nil {
+		if err := c.upsertAsset(ctx, tx, sourceID, snapshotID, assetID, canonicalIdentifier, fingerprint, deleted, needsClassification, asset); err != nil {
 			return err
 		}
+		identities.remember(assetID, canonicalIdentifier, c.snapshot.Provider, asset)
 	}
 
 	var missing int
@@ -221,12 +229,12 @@ where source_library_id = ? and last_seen_snapshot_id <> ?
 	return nil
 }
 
-func (c *crawlImporter) upsertAsset(ctx context.Context, tx *sql.Tx, sourceID, snapshotID, assetID, fingerprint string, deleted, needsClassification bool, asset photos.Asset) error {
+func (c *crawlImporter) upsertAsset(ctx context.Context, tx *sql.Tx, sourceID, snapshotID, assetID, canonicalIdentifier, fingerprint string, deleted, needsClassification bool, asset photos.Asset) error {
 	metadataJSON, err := jsonText(asset.Metadata)
 	if err != nil {
 		return err
 	}
-	assetArgs := []any{assetID, asset.LocalIdentifier, asset.MediaType, asset.MediaSubtypes, asset.CreationDate, asset.ModificationDate, asset.AddedDate, asset.TimezoneName, asset.Width, asset.Height, asset.DurationSeconds, boolInt(asset.Favorite), boolInt(asset.Hidden), asset.BurstIdentifier, boolInt(asset.RepresentsBurst), sourceID, metadataJSON}
+	assetArgs := []any{assetID, canonicalIdentifier, asset.MediaType, asset.MediaSubtypes, asset.CreationDate, asset.ModificationDate, asset.AddedDate, asset.TimezoneName, asset.Width, asset.Height, asset.DurationSeconds, boolInt(asset.Favorite), boolInt(asset.Hidden), asset.BurstIdentifier, boolInt(asset.RepresentsBurst), sourceID, metadataJSON}
 	assetStatement := c.stmts.assetLive
 	if deleted {
 		assetStatement = c.stmts.assetTombstone

--- a/internal/archive/faces.go
+++ b/internal/archive/faces.go
@@ -2,12 +2,10 @@ package archive
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -15,6 +13,7 @@ import (
 	"time"
 
 	"github.com/openclaw/crawlkit/store"
+	"github.com/openclaw/photoscrawl/internal/photos"
 )
 
 const photosLibraryDBFaceSource = "photos_library_db"
@@ -148,20 +147,20 @@ func ImportApple(ctx context.Context, paths Paths, opts ImportAppleOptions) (Imp
 	if err != nil {
 		return ImportAppleResult{}, err
 	}
-	archiveDB, err := openArchiveStore(ctx, paths.Database)
+	archiveDB, err := openAppleArchive(ctx, paths.Database, libraryPath)
 	if err != nil {
 		return ImportAppleResult{}, err
 	}
 	defer archiveDB.Close()
-	assetByUUID, err := archiveAssetMap(ctx, archiveDB.DB())
-	if err != nil {
-		return ImportAppleResult{}, err
-	}
 	tx, err := archiveDB.DB().BeginTx(ctx, nil)
 	if err != nil {
 		return ImportAppleResult{}, err
 	}
 	defer tx.Rollback()
+	assetByUUID, err := archiveAssetMap(ctx, tx, libraryPath)
+	if err != nil {
+		return ImportAppleResult{}, err
+	}
 	faces, faceAssets, err := writeFacesImport(ctx, tx, paths, facesInput, assetByUUID, importedAt)
 	if err != nil {
 		return ImportAppleResult{}, err
@@ -219,21 +218,21 @@ func ImportFaces(ctx context.Context, paths Paths, opts ImportFacesOptions) (Imp
 	if err != nil {
 		return ImportFacesResult{}, err
 	}
-	archiveDB, err := openArchiveStore(ctx, paths.Database)
+	archiveDB, err := openAppleArchive(ctx, paths.Database, libraryPath)
 	if err != nil {
 		return ImportFacesResult{}, err
 	}
 	defer archiveDB.Close()
 
-	assetByUUID, err := archiveAssetMap(ctx, archiveDB.DB())
-	if err != nil {
-		return ImportFacesResult{}, err
-	}
 	tx, err := archiveDB.DB().BeginTx(ctx, nil)
 	if err != nil {
 		return ImportFacesResult{}, err
 	}
 	defer tx.Rollback()
+	assetByUUID, err := archiveAssetMap(ctx, tx, libraryPath)
+	if err != nil {
+		return ImportFacesResult{}, err
+	}
 	result, _, err := writeFacesImport(ctx, tx, paths, input, assetByUUID, time.Now().UTC())
 	if err != nil {
 		return ImportFacesResult{}, err
@@ -257,16 +256,12 @@ func ImportSearchIndex(ctx context.Context, paths Paths, opts ImportSearchIndexO
 	if err != nil {
 		return ImportSearchIndexResult{}, err
 	}
-	archiveDB, err := openArchiveStore(ctx, paths.Database)
+	archiveDB, err := openAppleArchive(ctx, paths.Database, libraryPath)
 	if err != nil {
 		return ImportSearchIndexResult{}, err
 	}
 	defer archiveDB.Close()
 
-	assetByUUID, err := archiveAssetMap(ctx, archiveDB.DB())
-	if err != nil {
-		return ImportSearchIndexResult{}, err
-	}
 	peopleByUUID, err := loadPhotosPeopleByUUID(ctx, libraryPath)
 	if err != nil {
 		return ImportSearchIndexResult{}, err
@@ -276,6 +271,10 @@ func ImportSearchIndex(ctx context.Context, paths Paths, opts ImportSearchIndexO
 		return ImportSearchIndexResult{}, err
 	}
 	defer tx.Rollback()
+	assetByUUID, err := archiveAssetMap(ctx, tx, libraryPath)
+	if err != nil {
+		return ImportSearchIndexResult{}, err
+	}
 	result, _, err := writeSearchImport(ctx, tx, input, assetByUUID, peopleByUUID, time.Now().UTC())
 	if err != nil {
 		return ImportSearchIndexResult{}, err
@@ -359,15 +358,15 @@ func preflightSearchImport(ctx context.Context, libraryPath string) (searchImpor
 	return input, nil
 }
 
-func writeFacesImport(ctx context.Context, tx *sql.Tx, paths Paths, input facesImportInput, assetByUUID map[string]string, importedAt time.Time) (ImportFacesResult, map[string]bool, error) {
-	if err := clearImportedFaces(ctx, tx); err != nil {
+func writeFacesImport(ctx context.Context, tx *sql.Tx, paths Paths, input facesImportInput, assetByUUID appleAssetScope, importedAt time.Time) (ImportFacesResult, map[string]bool, error) {
+	if err := clearImportedFaces(ctx, tx, assetByUUID.libraryID); err != nil {
 		return ImportFacesResult{}, nil, err
 	}
 	inserted := 0
 	unresolved := 0
 	touched := map[string]bool{}
 	for _, face := range input.rows {
-		assetID, ok := assetByUUID[face.assetUUID]
+		assetID, ok := assetByUUID.byUUID[face.assetUUID]
 		if !ok {
 			unresolved++
 			continue
@@ -394,8 +393,8 @@ func writeFacesImport(ctx context.Context, tx *sql.Tx, paths Paths, input facesI
 	}, touched, nil
 }
 
-func writeSearchImport(ctx context.Context, tx *sql.Tx, input searchImportInput, assetByUUID map[string]string, peopleByUUID map[string]photosPerson, importedAt time.Time) (ImportSearchIndexResult, map[string]bool, error) {
-	if err := clearImportedSearchIndex(ctx, tx); err != nil {
+func writeSearchImport(ctx context.Context, tx *sql.Tx, input searchImportInput, assetByUUID appleAssetScope, peopleByUUID map[string]photosPerson, importedAt time.Time) (ImportSearchIndexResult, map[string]bool, error) {
+	if err := clearImportedSearchIndex(ctx, tx, assetByUUID.libraryID); err != nil {
 		return ImportSearchIndexResult{}, nil, err
 	}
 	result := ImportSearchIndexResult{
@@ -417,7 +416,7 @@ func writeSearchImport(ctx context.Context, tx *sql.Tx, input searchImportInput,
 		} else {
 			result.KnownCategoryRows++
 		}
-		assetID, ok := assetByUUID[row.assetUUID]
+		assetID, ok := assetByUUID.byUUID[row.assetUUID]
 		if !ok {
 			result.GroupsUnresolved++
 			continue
@@ -478,181 +477,8 @@ func copyPhotosSQLite(ctx context.Context, liveDBPath string) (string, func(), e
 	return copySQLite(ctx, liveDBPath, "photoscrawl-faces-")
 }
 
-type sqliteFileState struct {
-	exists      bool
-	size        int64
-	modifiedNS  int64
-	contentHash [sha256.Size]byte
-}
-
-func copySQLite(ctx context.Context, liveDBPath string, tempPrefix string) (string, func(), error) {
-	dir, err := os.MkdirTemp("", tempPrefix)
-	if err != nil {
-		return "", func() {}, err
-	}
-	cleanup := func() { _ = os.RemoveAll(dir) }
-	dest := filepath.Join(dir, filepath.Base(liveDBPath))
-	for attempt := 1; attempt <= 5; attempt++ {
-		if err := ctx.Err(); err != nil {
-			cleanup()
-			return "", func() {}, fmt.Errorf("snapshot SQLite source %s: %w", liveDBPath, err)
-		}
-		_ = os.Remove(dest)
-		_ = os.Remove(dest + "-wal")
-		before, err := statSQLiteFiles(liveDBPath)
-		if err != nil {
-			cleanup()
-			return "", func() {}, err
-		}
-		copied, err := copySQLiteFiles(liveDBPath, dest, before)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				continue
-			}
-			cleanup()
-			return "", func() {}, err
-		}
-		after, err := hashSQLiteFiles(liveDBPath)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				continue
-			}
-			cleanup()
-			return "", func() {}, err
-		}
-		if sqliteFilesStable(before, copied, after) {
-			if err := verifySQLiteSnapshot(ctx, dest); err == nil {
-				return dest, cleanup, nil
-			}
-		}
-	}
-	cleanup()
-	return "", func() {}, fmt.Errorf("create consistent SQLite snapshot: source kept changing during 5 attempts")
-}
-
-func statSQLiteFiles(dbPath string) (map[string]sqliteFileState, error) {
-	out := map[string]sqliteFileState{}
-	for _, suffix := range []string{"", "-wal"} {
-		path := dbPath + suffix
-		info, err := os.Stat(path)
-		if errors.Is(err, os.ErrNotExist) {
-			out[suffix] = sqliteFileState{}
-			continue
-		}
-		if err != nil {
-			return nil, fmt.Errorf("inspect SQLite source %s: %w", path, err)
-		}
-		out[suffix] = sqliteFileState{exists: true, size: info.Size(), modifiedNS: info.ModTime().UnixNano()}
-	}
-	if !out[""].exists {
-		return nil, fmt.Errorf("SQLite source does not exist: %s", dbPath)
-	}
-	return out, nil
-}
-
-func copySQLiteFiles(sourceDB, destDB string, before map[string]sqliteFileState) (map[string]sqliteFileState, error) {
-	out := map[string]sqliteFileState{}
-	for _, suffix := range []string{"", "-wal"} {
-		if !before[suffix].exists {
-			out[suffix] = sqliteFileState{}
-			continue
-		}
-		digest, err := copyFileWithHash(sourceDB+suffix, destDB+suffix, 0o600)
-		if err != nil {
-			return nil, err
-		}
-		state := before[suffix]
-		state.contentHash = digest
-		out[suffix] = state
-	}
-	return out, nil
-}
-
-func hashSQLiteFiles(dbPath string) (map[string]sqliteFileState, error) {
-	states, err := statSQLiteFiles(dbPath)
-	if err != nil {
-		return nil, err
-	}
-	for _, suffix := range []string{"", "-wal"} {
-		state := states[suffix]
-		if !state.exists {
-			continue
-		}
-		file, err := os.Open(dbPath + suffix)
-		if err != nil {
-			return nil, fmt.Errorf("open SQLite source %s: %w", dbPath+suffix, err)
-		}
-		digest := sha256.New()
-		_, copyErr := io.Copy(digest, file)
-		closeErr := file.Close()
-		if copyErr != nil {
-			return nil, fmt.Errorf("hash SQLite source %s: %w", dbPath+suffix, copyErr)
-		}
-		if closeErr != nil {
-			return nil, fmt.Errorf("close SQLite source %s: %w", dbPath+suffix, closeErr)
-		}
-		copy(state.contentHash[:], digest.Sum(nil))
-		states[suffix] = state
-	}
-	return states, nil
-}
-
-func sqliteFilesStable(before, copied, after map[string]sqliteFileState) bool {
-	for _, suffix := range []string{"", "-wal"} {
-		if before[suffix].exists != after[suffix].exists || copied[suffix].exists != after[suffix].exists {
-			return false
-		}
-		if !after[suffix].exists {
-			continue
-		}
-		if before[suffix].size != after[suffix].size || before[suffix].modifiedNS != after[suffix].modifiedNS {
-			return false
-		}
-		if copied[suffix].contentHash != after[suffix].contentHash {
-			return false
-		}
-	}
-	return true
-}
-
-func verifySQLiteSnapshot(ctx context.Context, path string) error {
-	db, err := store.OpenReadOnly(ctx, path)
-	if err != nil {
-		return err
-	}
-	defer db.Close()
-	var result string
-	if err := db.DB().QueryRowContext(ctx, `pragma quick_check`).Scan(&result); err != nil {
-		return err
-	}
-	if result != "ok" {
-		return fmt.Errorf("SQLite snapshot quick check: %s", result)
-	}
-	return nil
-}
-
-func copyFileWithHash(source, dest string, mode os.FileMode) ([sha256.Size]byte, error) {
-	var outHash [sha256.Size]byte
-	in, err := os.Open(source)
-	if err != nil {
-		return outHash, fmt.Errorf("open %s: %w", source, err)
-	}
-	defer in.Close()
-	out, err := os.OpenFile(dest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
-	if err != nil {
-		return outHash, fmt.Errorf("create %s: %w", dest, err)
-	}
-	digest := sha256.New()
-	_, copyErr := io.Copy(io.MultiWriter(out, digest), in)
-	closeErr := out.Close()
-	if copyErr != nil {
-		return outHash, fmt.Errorf("copy %s: %w", source, copyErr)
-	}
-	if closeErr != nil {
-		return outHash, fmt.Errorf("close %s: %w", dest, closeErr)
-	}
-	copy(outHash[:], digest.Sum(nil))
-	return outHash, nil
+func copySQLite(ctx context.Context, path, prefix string) (string, func(), error) {
+	return photos.CopySQLite(ctx, path, prefix)
 }
 
 func resolveAppleSearchDB(libraryPath string) (string, string, string, error) {
@@ -775,26 +601,6 @@ func tableColumns(ctx context.Context, db *sql.DB, table string) (map[string]boo
 		columns[name] = true
 	}
 	return columns, rows.Err()
-}
-
-func archiveAssetMap(ctx context.Context, db *sql.DB) (map[string]string, error) {
-	rows, err := db.QueryContext(ctx, `select id, local_identifier from asset`)
-	if err != nil {
-		return nil, fmt.Errorf("load archive assets: %w", err)
-	}
-	defer rows.Close()
-	out := map[string]string{}
-	for rows.Next() {
-		var assetID, localIdentifier string
-		if err := rows.Scan(&assetID, &localIdentifier); err != nil {
-			return nil, err
-		}
-		uuid := normalizeAssetLocalIdentifier(localIdentifier)
-		if uuid != "" {
-			out[uuid] = assetID
-		}
-	}
-	return out, rows.Err()
 }
 
 func normalizeAssetLocalIdentifier(localIdentifier string) string {
@@ -1089,42 +895,42 @@ func leoCategoryToPhotos8(category int) (int, bool) {
 	return mapped, ok
 }
 
-func clearImportedFaces(ctx context.Context, tx *sql.Tx) error {
+func clearImportedFaces(ctx context.Context, tx *sql.Tx, libraryID string) error {
 	if _, err := tx.ExecContext(ctx, `
 delete from observation_fts
 where id in (
-  select id from face_observation where source = ?
+  select id from face_observation where source = ? and asset_id in (select id from asset where source_library_id = ?)
 )
-`, photosLibraryDBFaceSource); err != nil {
+`, photosLibraryDBFaceSource, libraryID); err != nil {
 		return fmt.Errorf("clear imported face fts: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `delete from face_observation where source = ?`, photosLibraryDBFaceSource); err != nil {
+	if _, err := tx.ExecContext(ctx, `delete from face_observation where source = ? and asset_id in (select id from asset where source_library_id = ?)`, photosLibraryDBFaceSource, libraryID); err != nil {
 		return fmt.Errorf("clear imported faces: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `delete from evidence_ref where source = ? and evidence_kind = ?`, photosLibraryDBFaceSource, "face_observation"); err != nil {
+	if _, err := tx.ExecContext(ctx, `delete from evidence_ref where source = ? and evidence_kind = ? and asset_id in (select id from asset where source_library_id = ?)`, photosLibraryDBFaceSource, "face_observation", libraryID); err != nil {
 		return fmt.Errorf("clear imported face evidence: %w", err)
 	}
 	return nil
 }
 
-func clearImportedSearchIndex(ctx context.Context, tx *sql.Tx) error {
+func clearImportedSearchIndex(ctx context.Context, tx *sql.Tx, libraryID string) error {
 	if _, err := tx.ExecContext(ctx, `
 delete from observation_fts
 where id in (
-  select id from visual_observation where source = ?
+  select id from visual_observation where source = ? and asset_id in (select id from asset where source_library_id = ?)
   union
-  select id from face_observation where source = ?
+  select id from face_observation where source = ? and asset_id in (select id from asset where source_library_id = ?)
 )
-`, photosSearchIndexSource, photosSearchIndexSource); err != nil {
+`, photosSearchIndexSource, libraryID, photosSearchIndexSource, libraryID); err != nil {
 		return fmt.Errorf("clear Apple search index fts: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `delete from visual_observation where source = ?`, photosSearchIndexSource); err != nil {
+	if _, err := tx.ExecContext(ctx, `delete from visual_observation where source = ? and asset_id in (select id from asset where source_library_id = ?)`, photosSearchIndexSource, libraryID); err != nil {
 		return fmt.Errorf("clear Apple search index visual observations: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `delete from face_observation where source = ?`, photosSearchIndexSource); err != nil {
+	if _, err := tx.ExecContext(ctx, `delete from face_observation where source = ? and asset_id in (select id from asset where source_library_id = ?)`, photosSearchIndexSource, libraryID); err != nil {
 		return fmt.Errorf("clear Apple search index person observations: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `delete from evidence_ref where source = ? and evidence_kind = ?`, photosSearchIndexSource, "apple_search_index"); err != nil {
+	if _, err := tx.ExecContext(ctx, `delete from evidence_ref where source = ? and evidence_kind = ? and asset_id in (select id from asset where source_library_id = ?)`, photosSearchIndexSource, "apple_search_index", libraryID); err != nil {
 		return fmt.Errorf("clear Apple search index evidence: %w", err)
 	}
 	return nil

--- a/internal/archive/file_links_other.go
+++ b/internal/archive/file_links_other.go
@@ -1,0 +1,10 @@
+//go:build !unix && !windows
+
+package archive
+
+import "os"
+
+func archiveHardlinked(_ string, _ os.FileInfo) (bool, error) {
+	// These targets do not expose a link count through the supported OS APIs.
+	return false, nil
+}

--- a/internal/archive/file_links_unix.go
+++ b/internal/archive/file_links_unix.go
@@ -1,0 +1,13 @@
+//go:build unix
+
+package archive
+
+import (
+	"os"
+	"syscall"
+)
+
+func archiveHardlinked(_ string, info os.FileInfo) (bool, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Nlink > 1, nil
+}

--- a/internal/archive/file_links_windows.go
+++ b/internal/archive/file_links_windows.go
@@ -1,0 +1,19 @@
+package archive
+
+import (
+	"os"
+	"syscall"
+)
+
+func archiveHardlinked(path string, _ os.FileInfo) (bool, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+	var info syscall.ByHandleFileInformation
+	if err := syscall.GetFileInformationByHandle(syscall.Handle(file.Fd()), &info); err != nil {
+		return false, err
+	}
+	return info.NumberOfLinks > 1, nil
+}

--- a/internal/archive/migrations.go
+++ b/internal/archive/migrations.go
@@ -6,14 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/openclaw/crawlkit/store"
 	"github.com/openclaw/photoscrawl/internal/photos"
 )
 
 func openArchiveStore(ctx context.Context, path string) (*store.Store, error) {
-	sqlitePath, err := filepath.Abs(path)
+	sqlitePath, err := archiveFilename(path)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +126,7 @@ func preflightArchive(ctx context.Context, path string) error {
 }
 
 func openArchiveReadOnly(ctx context.Context, path string) (*store.Store, error) {
-	sqlitePath, err := filepath.Abs(path)
+	sqlitePath, err := archiveFilename(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/archive/migrations.go
+++ b/internal/archive/migrations.go
@@ -5,12 +5,22 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/openclaw/crawlkit/store"
+	"github.com/openclaw/photoscrawl/internal/photos"
 )
 
 func openArchiveStore(ctx context.Context, path string) (*store.Store, error) {
-	db, err := store.Open(ctx, store.Options{Path: path})
+	if err := preflightArchive(ctx, path); err != nil {
+		return nil, err
+	}
+	sqlitePath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	db, err := store.Open(ctx, store.Options{Path: sqlitePath})
 	if err != nil {
 		return nil, err
 	}
@@ -55,8 +65,73 @@ func openArchiveStore(ctx context.Context, path string) (*store.Store, error) {
 	return db, nil
 }
 
+func preflightArchive(ctx context.Context, path string) error {
+	// Reject accidental foreign-file selection without opening it writable.
+	// As with SQLite's pathname API, callers must keep the path stable through open.
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return inspectArchiveSidecars(path, true)
+	}
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("archive must be a regular file")
+	}
+	if err := inspectArchiveSidecars(path, false); err != nil {
+		return err
+	}
+	linked, err := archiveHardlinked(path, info)
+	if err != nil {
+		return err
+	}
+	if linked {
+		return errors.New("cannot write a hardlinked archive: SQLite sidecars belong to a single filename")
+	}
+	private, cleanup, err := photos.CopySQLite(ctx, path, "photoscrawl-preflight-")
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	db, err := store.OpenReadOnly(ctx, private)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	current, err := db.SchemaVersion(ctx)
+	if err != nil {
+		return err
+	}
+	if current > SchemaVersion {
+		return fmt.Errorf("database schema version %d is newer than supported version %d", current, SchemaVersion)
+	}
+	isArchive, err := archiveTablesPresent(ctx, db.DB())
+	if err != nil {
+		return err
+	}
+	empty, err := archiveDatabaseEmpty(ctx, db.DB())
+	if err != nil {
+		return err
+	}
+	if !isArchive && (!empty || current != 0) {
+		return errors.New("database is not a photoscrawl archive")
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !os.SameFile(info, after) {
+		return errors.New("archive changed identity during validation")
+	}
+	return nil
+}
+
 func openArchiveReadOnly(ctx context.Context, path string) (*store.Store, error) {
-	db, err := store.OpenReadOnly(ctx, path)
+	sqlitePath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	db, err := store.OpenReadOnly(ctx, sqlitePath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/archive/migrations.go
+++ b/internal/archive/migrations.go
@@ -78,7 +78,7 @@ func preflightArchive(ctx context.Context, path string) error {
 	if !info.Mode().IsRegular() {
 		return errors.New("archive must be a regular file")
 	}
-	if err := inspectArchiveSidecars(path, false); err != nil {
+	if err := inspectArchiveSidecars(path, info.Size() == 0); err != nil {
 		return err
 	}
 	linked, err := archiveHardlinked(path, info)

--- a/internal/archive/migrations.go
+++ b/internal/archive/migrations.go
@@ -13,11 +13,11 @@ import (
 )
 
 func openArchiveStore(ctx context.Context, path string) (*store.Store, error) {
-	if err := preflightArchive(ctx, path); err != nil {
-		return nil, err
-	}
 	sqlitePath, err := filepath.Abs(path)
 	if err != nil {
+		return nil, err
+	}
+	if err := preflightArchive(ctx, sqlitePath); err != nil {
 		return nil, err
 	}
 	db, err := store.Open(ctx, store.Options{Path: sqlitePath})

--- a/internal/archive/path_consistency_test.go
+++ b/internal/archive/path_consistency_test.go
@@ -6,8 +6,219 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/openclaw/crawlkit/store"
 )
+
+func TestArchiveWhitespaceTargetBoundAlias(t *testing.T) {
+	for _, caller := range []string{"archive", "apple"} {
+		t.Run(caller, func(t *testing.T) {
+			ctx := context.Background()
+			root := t.TempDir()
+			ordinary := filepath.Join(root, "ordinary.db")
+			target := filepath.Join(root, "bound.db ")
+			alias := filepath.Join(root, "alias.db")
+			library := filepath.Join(root, "synthetic.photoslibrary")
+			db, err := openArchiveStore(ctx, ordinary)
+			if err != nil {
+				t.Fatal(err)
+			}
+			execTestSQL(t, db.DB(), "pragma journal_mode=DELETE")
+			execTestSQL(t, db.DB(), `insert into source_library values('retained-library', ?, '', '', '', '{}')`, library)
+			execTestSQL(t, db.DB(), "create table retained_marker(value text)")
+			execTestSQL(t, db.DB(), "insert into retained_marker values('bound-row')")
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			bundle := pathFixtureFiles(t, ordinary)
+			if len(bundle[""].data) == 0 {
+				t.Fatal("fixture archive is empty")
+			}
+			for suffix := range bundle {
+				if err := os.Rename(ordinary+suffix, target+suffix); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if !reflect.DeepEqual(bundle, pathFixtureFiles(t, target)) || len(pathFixtureFiles(t, ordinary)) != 0 {
+				t.Fatal("fixture bundle move was incomplete")
+			}
+			check, err := sql.Open("sqlite", target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			requireLiteralArchiveTarget(t, check, target, "DELETE")
+			requireBoundMarker(t, ctx, check, library)
+			if err := check.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, alias); err != nil {
+				t.Fatal(err)
+			}
+			link := requireArchiveAlias(t, alias, target, nil)
+			t.Log("moved literal archive, binding, marker and alias verified before subject")
+			var opened *store.Store
+			if caller == "apple" {
+				opened, err = openAppleArchive(ctx, alias, library)
+			} else {
+				opened, err = openArchiveStore(ctx, alias)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer opened.Close()
+			requireBoundMarker(t, ctx, opened.DB(), library)
+			requireArchiveAlias(t, alias, target, link)
+			requireArchivePathAbsent(t, strings.TrimSpace(target))
+			requireArchiveAliasSidecarsAbsent(t, alias)
+		})
+	}
+}
+
+func TestArchiveWhitespaceTargetForeignRefusal(t *testing.T) {
+	for _, journal := range []string{"DELETE", "WAL"} {
+		for _, caller := range []string{"archive", "init", "apple"} {
+			t.Run(journal+"/"+caller, func(t *testing.T) {
+				ctx := context.Background()
+				root := t.TempDir()
+				target := filepath.Join(root, "foreign.db ")
+				alias := filepath.Join(root, "alias.db")
+				writer, err := sql.Open("sqlite", target)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer writer.Close()
+				writer.SetMaxOpenConns(1)
+				execTestSQL(t, writer, "pragma journal_mode="+journal)
+				execTestSQL(t, writer, "pragma wal_autocheckpoint=0")
+				execTestSQL(t, writer, "create table foreign_marker(value text)")
+				execTestSQL(t, writer, "insert into foreign_marker values('committed-foreign-row')")
+				requireLiteralArchiveTarget(t, writer, target, journal)
+				var marker string
+				if err := writer.QueryRow("select value from foreign_marker").Scan(&marker); err != nil || marker != "committed-foreign-row" {
+					t.Fatalf("fixture marker = %q: %v", marker, err)
+				}
+				if err := os.Chmod(target, 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, alias); err != nil {
+					t.Fatal(err)
+				}
+				link := requireArchiveAlias(t, alias, target, nil)
+				before := pathFixtureFiles(t, target)
+				if journal == "WAL" && len(before["-wal"].data) == 0 {
+					t.Fatal("fixture has no committed WAL")
+				}
+				t.Log("literal foreign filename, identity, journal, marker and alias verified before subject")
+				var opened *store.Store
+				switch caller {
+				case "archive":
+					opened, err = openArchiveStore(ctx, alias)
+				case "init":
+					_, err = Init(ctx, Paths{Database: alias})
+				case "apple":
+					opened, err = openAppleArchive(ctx, alias, filepath.Join(root, "synthetic.photoslibrary"))
+				}
+				if opened != nil {
+					opened.Close()
+				}
+				if err == nil {
+					t.Error("foreign target accepted")
+				}
+				// Compare while the source connection still owns its committed WAL.
+				after := pathFixtureFiles(t, target)
+				if !reflect.DeepEqual(before, after) {
+					for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
+						want, had := before[suffix]
+						got, has := after[suffix]
+						if had != has || !reflect.DeepEqual(want, got) {
+							t.Errorf("foreign %q changed: present %t -> %t, mode %v -> %v, bytes %d -> %d",
+								suffix, had, has, want.mode, got.mode, len(want.data), len(got.data))
+						}
+					}
+				}
+				requireArchiveAlias(t, alias, target, link)
+				requireArchiveAliasSidecarsAbsent(t, alias)
+				requireArchivePathAbsent(t, strings.TrimSpace(target))
+			})
+		}
+	}
+}
+
+func requireLiteralArchiveTarget(t *testing.T, db *sql.DB, target, journal string) {
+	t.Helper()
+	var seq int
+	var name, filename, mode string
+	if err := db.QueryRow("pragma database_list").Scan(&seq, &name, &filename); err != nil {
+		t.Fatal(err)
+	}
+	if name != "main" || filename != target {
+		t.Fatalf("fixture SQLite filename = %q (%q), want literal %q", filename, name, target)
+	}
+	selected, err := os.Stat(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	literal, err := os.Stat(target)
+	if err != nil || !os.SameFile(selected, literal) {
+		t.Fatalf("fixture literal identity mismatch: %v", err)
+	}
+	if err := db.QueryRow("pragma journal_mode").Scan(&mode); err != nil || !strings.EqualFold(mode, journal) {
+		t.Fatalf("fixture journal mode = %q, want %q: %v", mode, journal, err)
+	}
+	requireArchivePathAbsent(t, strings.TrimSpace(target))
+}
+
+func requireBoundMarker(t *testing.T, ctx context.Context, db *sql.DB, library string) {
+	t.Helper()
+	id, err := libraryIdentity(ctx, db, library)
+	if err != nil || id != "retained-library" {
+		t.Fatalf("retained binding = %q: %v", id, err)
+	}
+	var marker string
+	if err := db.QueryRow("select value from retained_marker").Scan(&marker); err != nil || marker != "bound-row" {
+		t.Fatalf("retained marker = %q: %v", marker, err)
+	}
+}
+
+func requireArchiveAlias(t *testing.T, alias, target string, previous os.FileInfo) os.FileInfo {
+	t.Helper()
+	link, err := os.Lstat(alias)
+	if err != nil || link.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("fixture alias is not a symlink: %v", err)
+	}
+	if previous != nil && (!os.SameFile(previous, link) || previous.Mode() != link.Mode()) {
+		t.Fatal("alias identity or mode changed")
+	}
+	resolved, err := filepath.EvalSymlinks(alias)
+	if err != nil || resolved != target {
+		t.Fatalf("fixture alias resolves to %q, want %q: %v", resolved, target, err)
+	}
+	selected, err := os.Stat(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	literal, err := os.Stat(target)
+	if err != nil || !os.SameFile(selected, literal) {
+		t.Fatalf("fixture alias identity mismatch: %v", err)
+	}
+	return link
+}
+
+func requireArchivePathAbsent(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Fatalf("unexpected path %q: %v", path, err)
+	}
+}
+
+func requireArchiveAliasSidecarsAbsent(t *testing.T, alias string) {
+	t.Helper()
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		requireArchivePathAbsent(t, alias+suffix)
+	}
+}
 
 func TestArchiveOpenValidatesActualSQLiteFilename(t *testing.T) {
 	ctx := context.Background()

--- a/internal/archive/path_consistency_test.go
+++ b/internal/archive/path_consistency_test.go
@@ -1,0 +1,132 @@
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestArchiveOpenValidatesActualSQLiteFilename(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "a", "b"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	valid := filepath.Join(root, "a", "archive.db")
+	archive, err := openArchiveStore(ctx, valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	foreign := filepath.Join(root, "archive.db")
+	db, err := sql.Open("sqlite", foreign)
+	if err != nil {
+		t.Fatal(err)
+	}
+	execTestSQL(t, db, "pragma journal_mode=DELETE")
+	execTestSQL(t, db, "create table foreign_marker(value text)")
+	execTestSQL(t, db, "insert into foreign_marker values ('synthetic-only')")
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(foreign, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(root, "a", "b"), filepath.Join(root, "alias")); err != nil {
+		t.Fatal(err)
+	}
+	// Join would erase the static spelling whose two interpretations differ.
+	raw := root + "/alias/../archive.db"
+	actual, err := filepath.Abs(raw)
+	if err != nil || actual != foreign {
+		t.Fatalf("actual SQLite filename = %q: %v", actual, err)
+	}
+	rawInfo, err := os.Stat(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validInfo, err := os.Stat(valid)
+	if err != nil || !os.SameFile(rawInfo, validInfo) {
+		t.Fatalf("raw path did not select valid fixture: %v", err)
+	}
+	before, validBefore := pathFixtureFiles(t, foreign), pathFixtureFiles(t, valid)
+	opened, err := openArchiveStore(ctx, raw)
+	if opened != nil {
+		opened.Close()
+	}
+	if err == nil {
+		t.Error("foreign actual filename accepted")
+	}
+	if !reflect.DeepEqual(before, pathFixtureFiles(t, foreign)) {
+		t.Error("foreign bytes, modes or sidecar inventory changed")
+	}
+	if !reflect.DeepEqual(validBefore, pathFixtureFiles(t, valid)) {
+		t.Error("raw-path valid archive changed")
+	}
+}
+
+type pathFixtureFile struct {
+	mode os.FileMode
+	data []byte
+}
+
+func pathFixtureFiles(t *testing.T, path string) map[string]pathFixtureFile {
+	t.Helper()
+	files := map[string]pathFixtureFile{}
+	for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
+		info, err := os.Stat(path + suffix)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(path + suffix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[suffix] = pathFixtureFile{info.Mode(), data}
+	}
+	return files
+}
+
+func TestArchiveOpenPathCompatibility(t *testing.T) {
+	for _, kind := range []string{"symlink", "dangling", "literal-uri-name"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			path, target := "alias.db", "target.db"
+			if kind == "literal-uri-name" {
+				path, target = "file:literal.db", "file:literal.db"
+			} else {
+				if kind == "symlink" {
+					db, err := openArchiveStore(context.Background(), target)
+					if err != nil {
+						t.Fatal(err)
+					}
+					db.Close()
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatal(err)
+				}
+			}
+			db, err := openArchiveStore(context.Background(), path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			db.Close()
+			if _, err := os.Stat(target); err != nil {
+				t.Fatal(err)
+			}
+			if kind == "literal-uri-name" {
+				if _, err := os.Stat("literal.db"); !os.IsNotExist(err) {
+					t.Fatalf("literal filename interpreted as URI: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/archive/path_consistency_test.go
+++ b/internal/archive/path_consistency_test.go
@@ -16,7 +16,10 @@ func TestArchiveWhitespaceTargetBoundAlias(t *testing.T) {
 	for _, caller := range []string{"archive", "apple"} {
 		t.Run(caller, func(t *testing.T) {
 			ctx := context.Background()
-			root := t.TempDir()
+			root, err := filepath.EvalSymlinks(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
 			ordinary := filepath.Join(root, "ordinary.db")
 			target := filepath.Join(root, "bound.db ")
 			alias := filepath.Join(root, "alias.db")
@@ -81,7 +84,10 @@ func TestArchiveWhitespaceTargetForeignRefusal(t *testing.T) {
 		for _, caller := range []string{"archive", "init", "apple"} {
 			t.Run(journal+"/"+caller, func(t *testing.T) {
 				ctx := context.Background()
-				root := t.TempDir()
+				root, err := filepath.EvalSymlinks(t.TempDir())
+				if err != nil {
+					t.Fatal(err)
+				}
 				target := filepath.Join(root, "foreign.db ")
 				alias := filepath.Join(root, "alias.db")
 				writer, err := sql.Open("sqlite", target)

--- a/internal/archive/preflight_test.go
+++ b/internal/archive/preflight_test.go
@@ -108,6 +108,31 @@ func TestArchivePreflightAllowsOrdinaryEmptyFile(t *testing.T) {
 	db.Close()
 }
 
+func TestArchivePreflightRejectsSidecarsBesideEmptyArchive(t *testing.T) {
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		t.Run(suffix, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "archive.db")
+			if err := os.WriteFile(path, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			orphan := []byte("synthetic orphan sidecar")
+			if err := os.WriteFile(path+suffix, orphan, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if db, err := openArchiveStore(context.Background(), path); err == nil {
+				db.Close()
+				t.Error("orphan sidecar beside empty archive accepted")
+			}
+			if info, err := os.Stat(path); err != nil || info.Size() != 0 {
+				t.Fatalf("empty archive changed: %v", err)
+			}
+			if got, err := os.ReadFile(path + suffix); err != nil || !bytes.Equal(got, orphan) {
+				t.Fatalf("orphan %s changed: %v", suffix, err)
+			}
+		})
+	}
+}
+
 func TestArchivePreflightPreservesForeignSource(t *testing.T) {
 	for _, journal := range []string{"DELETE", "WAL"} {
 		t.Run(journal, func(t *testing.T) {

--- a/internal/archive/preflight_test.go
+++ b/internal/archive/preflight_test.go
@@ -1,0 +1,167 @@
+package archive
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestArchivePreflightRejectsPopulatedHardlinks(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	source, alias := filepath.Join(root, "archive.db"), filepath.Join(root, "alias.db")
+	db, err := openArchiveStore(ctx, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := sql.Open("sqlite", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	execTestSQL(t, writer, "pragma journal_mode=WAL")
+	execTestSQL(t, writer, "create table committed_in_wal(value text)")
+	execTestSQL(t, writer, "insert into committed_in_wal values ('synthetic')")
+	if err := os.Link(source, alias); err != nil {
+		t.Fatal(err)
+	}
+	before, modes := map[string][]byte{}, map[string]os.FileMode{}
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		before[suffix], err = os.ReadFile(source + suffix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err := os.Stat(source + suffix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		modes[suffix] = info.Mode()
+	}
+	for _, candidate := range []string{source, alias} {
+		archive, err := openArchiveStore(ctx, candidate)
+		if err == nil {
+			archive.Close()
+			t.Fatalf("populated hardlink %s accepted", filepath.Base(candidate))
+		}
+		if !strings.Contains(err.Error(), "hardlinked") {
+			t.Fatalf("hardlink refusal lost: %v", err)
+		}
+	}
+	for suffix, want := range before {
+		got, err := os.ReadFile(source + suffix)
+		if err != nil || !bytes.Equal(got, want) {
+			t.Fatalf("source %q changed: %v", suffix, err)
+		}
+		info, err := os.Stat(source + suffix)
+		if err != nil || info.Mode() != modes[suffix] {
+			t.Fatalf("source %q mode changed: %v", suffix, err)
+		}
+	}
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		if _, err := os.Stat(alias + suffix); !os.IsNotExist(err) {
+			t.Fatalf("alias sidecar %q created: %v", suffix, err)
+		}
+	}
+}
+
+func TestArchivePreflightRejectsUnownedSidecars(t *testing.T) {
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		t.Run(suffix, func(t *testing.T) {
+			root := t.TempDir()
+			foreign, path := filepath.Join(root, "foreign.db"), filepath.Join(root, "archive.db")
+			if err := os.WriteFile(foreign, []byte("caller-owned bytes"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(foreign, path+suffix); err != nil {
+				t.Fatal(err)
+			}
+			if db, err := openArchiveStore(context.Background(), path); err == nil {
+				db.Close()
+				t.Fatal("unowned sidecar accepted")
+			}
+			if got, err := os.ReadFile(foreign); err != nil || string(got) != "caller-owned bytes" {
+				t.Fatalf("foreign sidecar target changed: %v", err)
+			}
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatalf("archive created before rejection: %v", err)
+			}
+		})
+	}
+}
+
+func TestArchivePreflightAllowsOrdinaryEmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.db")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	db, err := openArchiveStore(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+}
+
+func TestArchivePreflightPreservesForeignSource(t *testing.T) {
+	for _, journal := range []string{"DELETE", "WAL"} {
+		t.Run(journal, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, "Photos.sqlite")
+			db, err := sql.Open("sqlite", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			execTestSQL(t, db, "pragma journal_mode="+journal)
+			execTestSQL(t, db, "create table ZASSET(ZUUID text)")
+			if err := os.Chmod(path, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			before, modes := map[string][]byte{}, map[string]os.FileMode{}
+			for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
+				data, err := os.ReadFile(path + suffix)
+				if os.IsNotExist(err) {
+					continue
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				info, err := os.Stat(path + suffix)
+				if err != nil {
+					t.Fatal(err)
+				}
+				before[suffix], modes[suffix] = data, info.Mode()
+			}
+			link := filepath.Join(root, "alias.sqlite")
+			if err := os.Link(path, link); err != nil {
+				t.Fatal(err)
+			}
+			for _, candidate := range []string{path, link} {
+				if archive, err := openArchiveStore(context.Background(), candidate); err == nil {
+					_ = archive.Close()
+					t.Fatal("foreign source accepted")
+				}
+			}
+			for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
+				got, err := os.ReadFile(path + suffix)
+				want, existed := before[suffix]
+				if !existed && os.IsNotExist(err) {
+					continue
+				}
+				if err != nil || !existed || !bytes.Equal(got, want) {
+					t.Fatalf("source %q changed: %v", suffix, err)
+				}
+				info, err := os.Stat(path + suffix)
+				if err != nil || info.Mode() != modes[suffix] {
+					t.Fatalf("source %q mode changed: %v", suffix, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/archive/sidecars.go
+++ b/internal/archive/sidecars.go
@@ -1,0 +1,71 @@
+package archive
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func inspectArchiveSidecars(path string, missing bool) error {
+	base, err := archiveSidecarBase(path, 0)
+	if err != nil {
+		return err
+	}
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		info, err := os.Lstat(base + suffix)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if missing || !info.Mode().IsRegular() {
+			return errors.New("archive has an unowned or non-regular SQLite sidecar")
+		}
+		linked, err := archiveHardlinked(base+suffix, info)
+		if err != nil {
+			return err
+		}
+		if linked {
+			return errors.New("archive has a hardlinked SQLite sidecar")
+		}
+	}
+	return nil
+}
+
+func archiveSidecarBase(path string, links int) (string, error) {
+	if links > 255 {
+		return "", errors.New("too many symbolic links in archive path")
+	}
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	info, statErr := os.Lstat(path)
+	if statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(path)
+		if err != nil {
+			return "", err
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(path), target)
+		}
+		return archiveSidecarBase(target, links+1)
+	}
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return "", statErr
+	}
+	parent := filepath.Dir(path)
+	if parent == path {
+		return "", err
+	}
+	resolved, err = archiveSidecarBase(parent, links)
+	return filepath.Join(resolved, filepath.Base(path)), err
+}

--- a/internal/evalcard/evalcard.go
+++ b/internal/evalcard/evalcard.go
@@ -55,6 +55,7 @@ type Result struct {
 	Sample                string         `json:"sample"`
 	AllowICloudDownloads  bool           `json:"allow_icloud_downloads"`
 	AssetsSeen            int            `json:"assets_seen"`
+	AssetsAttempted       int            `json:"assets_attempted"`
 	AssetsPrepared        int            `json:"assets_prepared"`
 	AssetsSkipped         map[string]int `json:"assets_skipped,omitempty"`
 	ModelCallsAttempted   int            `json:"model_calls_attempted"`
@@ -198,12 +199,23 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 	writer := bufio.NewWriter(manifest)
 
 	inputs := []preparedInput{}
+	budget := &originalBudget{remaining: maxRunOriginalBytes}
+	// Limit attempts as well as successful cards. Failed rendering must not
+	// download every original in a library while trying to fill the sample.
+	attemptLimit := limit
+	if limit <= int(^uint(0)>>1)/3 {
+		attemptLimit = limit * 3
+	}
 	for _, asset := range assets {
-		if len(inputs) >= limit {
+		if len(inputs) >= limit || result.AssetsAttempted >= attemptLimit {
 			break
 		}
+		if err := ctx.Err(); err != nil {
+			return Result{}, err
+		}
+		result.AssetsAttempted++
 		id := fmt.Sprintf("E%03d", len(inputs)+1)
-		input, row, err := prepareInput(ctx, localMedia, outputDir, cacheDir, id, asset, opts.AllowICloudDownloads)
+		input, row, err := prepareInput(ctx, localMedia, outputDir, cacheDir, id, asset, opts.AllowICloudDownloads, budget)
 		if err != nil {
 			result.AssetsSkipped[classifySkip(err)]++
 			continue
@@ -240,16 +252,17 @@ func Run(ctx context.Context, opts Options) (Result, error) {
 	return result, nil
 }
 
-func prepareInput(ctx context.Context, localMedia photos.LocalMediaIndex, outputDir, cacheDir, id string, asset photos.Asset, allowICloud bool) (preparedInput, manifestRow, error) {
-	originalPath, source, err := resolveOriginal(ctx, localMedia, cacheDir, asset, allowICloud)
+func prepareInput(ctx context.Context, localMedia photos.LocalMediaIndex, outputDir, cacheDir, id string, asset photos.Asset, allowICloud bool, budget *originalBudget) (preparedInput, manifestRow, error) {
+	originalPath, source, cleanup, err := resolveOriginal(ctx, localMedia, cacheDir, asset, allowICloud, budget)
 	if err != nil {
 		return preparedInput{}, manifestRow{}, err
 	}
+	defer cleanup()
 	imagePath := filepath.Join(outputDir, "images", id+".jpg")
-	if err := photos.RenderCanonicalJPEG(ctx, originalPath, imagePath, 0.92); err != nil {
+	if err := renderEvalImage(ctx, originalPath, imagePath, 0.92); err != nil {
 		return preparedInput{}, manifestRow{}, fmt.Errorf("canonical_render")
 	}
-	imageMeta, err := photos.ImageMetadata(ctx, originalPath)
+	imageMeta, err := readEvalMetadata(ctx, originalPath)
 	if err != nil {
 		return preparedInput{}, manifestRow{}, fmt.Errorf("image_metadata")
 	}
@@ -285,24 +298,25 @@ func prepareInput(ctx context.Context, localMedia photos.LocalMediaIndex, output
 	}, nil
 }
 
-func resolveOriginal(ctx context.Context, localMedia photos.LocalMediaIndex, cacheDir string, asset photos.Asset, allowICloud bool) (string, string, error) {
+func resolveOriginal(ctx context.Context, localMedia photos.LocalMediaIndex, cacheDir string, asset photos.Asset, allowICloud bool, budget *originalBudget) (string, string, func(), error) {
 	candidates := localMedia.Candidates(asset.LocalIdentifier)
 	for _, candidate := range candidates {
 		if candidate.Class == "original" {
-			return candidate.Path, "photos_package_original", nil
+			return candidate.Path, "photos_package_original", func() {}, nil
 		}
 	}
 	cachePath := filepath.Join(cacheDir, cacheName(asset))
-	if info, err := os.Stat(cachePath); err == nil && info.Size() > 0 {
-		return cachePath, "cached_photokit_original", nil
+	if info, err := os.Lstat(cachePath); err == nil && info.Mode().IsRegular() && info.Size() > 0 && info.Size() <= maxOriginalBytes {
+		return cachePath, "cached_photokit_original", func() {}, nil
 	}
 	if !allowICloud {
-		return "", "", fmt.Errorf("missing_original")
+		return "", "", func() {}, fmt.Errorf("missing_original")
 	}
-	if err := photos.ExportOriginalResource(ctx, asset.LocalIdentifier, cachePath, true); err != nil {
-		return "", "", fmt.Errorf("export_original")
+	path, cleanup, err := budget.export(ctx, cacheDir, asset)
+	if err != nil {
+		return "", "", func() {}, err
 	}
-	return cachePath, "photokit_original_export", nil
+	return path, "photokit_original_export_temporary", cleanup, nil
 }
 
 func imageAssets(assets []photos.Asset, sample string, seed uint64) []photos.Asset {

--- a/internal/evalcard/original_budget.go
+++ b/internal/evalcard/original_budget.go
@@ -1,0 +1,50 @@
+package evalcard
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/openclaw/photoscrawl/internal/photos"
+)
+
+const maxOriginalBytes int64 = 256 << 20
+const maxRunOriginalBytes int64 = 512 << 20
+
+type originalBudget struct {
+	remaining int64
+}
+
+var exportEvalOriginal = photos.ExportOriginalResourceLimited
+var renderEvalImage = photos.RenderCanonicalJPEG
+var readEvalMetadata = photos.ImageMetadata
+
+func (b *originalBudget) export(ctx context.Context, cacheDir string, asset photos.Asset) (string, func(), error) {
+	limit := min(maxOriginalBytes, b.remaining)
+	if limit <= 0 {
+		return "", func() {}, errors.New("original_byte_budget")
+	}
+	// PhotoKit selects one original resource. A larger paired video must not
+	// exclude its still image; enforce the limit on the selected byte stream.
+	root, err := os.MkdirTemp(cacheDir, "eval-original-")
+	if err != nil {
+		return "", func() {}, err
+	}
+	cleanup := func() { _ = os.RemoveAll(root) }
+	path := filepath.Join(root, cacheName(asset))
+	// Reserve before streaming; failed exports may have consumed the full
+	// allowance. Only successful, verified sizes can refund unused bytes.
+	b.remaining -= limit
+	if err := exportEvalOriginal(ctx, asset.LocalIdentifier, path, true, limit); err != nil {
+		cleanup()
+		return "", func() {}, errors.New("export_original")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > limit {
+		cleanup()
+		return "", func() {}, errors.New("invalid_exported_original")
+	}
+	b.remaining += limit - info.Size()
+	return path, cleanup, nil
+}

--- a/internal/evalcard/original_budget_test.go
+++ b/internal/evalcard/original_budget_test.go
@@ -1,0 +1,143 @@
+package evalcard
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/photoscrawl/internal/photos"
+)
+
+type budgetProvider struct{ assets []photos.Asset }
+
+func (p budgetProvider) Snapshot(context.Context, string) (photos.LibrarySnapshot, error) {
+	return photos.LibrarySnapshot{Assets: p.assets}, nil
+}
+
+func TestEvalAttemptsAndOriginalCleanupAreBounded(t *testing.T) {
+	oldExport, oldRender := exportEvalOriginal, renderEvalImage
+	t.Cleanup(func() { exportEvalOriginal, renderEvalImage = oldExport, oldRender })
+	calls := 0
+	exportEvalOriginal = func(ctx context.Context, id, path string, network bool, limit int64) error {
+		calls++
+		if !network || limit <= 0 || limit > maxOriginalBytes {
+			t.Fatalf("export allowance = %d, network=%v", limit, network)
+		}
+		return os.WriteFile(path, []byte("synthetic original"), 0o600)
+	}
+	renderEvalImage = func(context.Context, string, string, float64) error {
+		return errors.New("synthetic render failure")
+	}
+	opts, _ := evalRunOptions(t)
+	assets := make([]photos.Asset, 100)
+	for i := range assets {
+		assets[i] = photos.Asset{LocalIdentifier: "synthetic", MediaType: "image"}
+	}
+	opts.Provider = budgetProvider{assets}
+	opts.Limit = 2
+	opts.AllowICloudDownloads = true
+	for run := 0; run < 2; run++ {
+		calls = 0
+		result, err := Run(context.Background(), opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.AssetsAttempted != 6 || calls != 6 || result.AssetsPrepared != 0 {
+			t.Fatalf("attempted=%d exported=%d prepared=%d", result.AssetsAttempted, calls, result.AssetsPrepared)
+		}
+		entries, err := os.ReadDir(opts.CacheDir)
+		if err != nil || len(entries) != 0 {
+			t.Fatalf("failed originals retained: %d, %v", len(entries), err)
+		}
+	}
+}
+
+func TestOriginalBudgetRejectsOversizeAndStopsFailedExports(t *testing.T) {
+	old := exportEvalOriginal
+	t.Cleanup(func() { exportEvalOriginal = old })
+	calls := 0
+	exportEvalOriginal = func(ctx context.Context, id, path string, network bool, limit int64) error {
+		calls++
+		return os.WriteFile(path, make([]byte, limit+1), 0o600)
+	}
+	cache := t.TempDir()
+	budget := originalBudget{remaining: 10}
+	asset := photos.Asset{LocalIdentifier: "synthetic", MediaType: "image"}
+	if _, _, err := budget.export(context.Background(), cache, asset); err == nil {
+		t.Fatal("oversized original accepted")
+	}
+	if _, _, err := budget.export(context.Background(), cache, asset); err == nil || calls != 1 {
+		t.Fatalf("exhausted budget performed another export: calls=%d err=%v", calls, err)
+	}
+	entries, err := os.ReadDir(cache)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("oversized original retained: %v", err)
+	}
+}
+
+func TestOriginalBudgetAllowsSmallStillWithLargePairedVideo(t *testing.T) {
+	old := exportEvalOriginal
+	t.Cleanup(func() { exportEvalOriginal = old })
+	calls := 0
+	exportEvalOriginal = func(ctx context.Context, id, path string, network bool, limit int64) error {
+		calls++
+		if limit != 10 {
+			t.Fatalf("streaming limit = %d", limit)
+		}
+		return os.WriteFile(path, []byte("still"), 0o600)
+	}
+	cache := t.TempDir()
+	budget := originalBudget{remaining: 10}
+	asset := photos.Asset{
+		LocalIdentifier: "synthetic", MediaType: "image",
+		Resources: []photos.Resource{
+			{Type: "photo", FileSize: 5},
+			{Type: "paired_video", FileSize: maxOriginalBytes + 1},
+		},
+	}
+	path, cleanup, err := budget.export(context.Background(), cache, asset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup()
+	if calls != 1 || budget.remaining != 5 {
+		t.Fatalf("calls=%d remaining=%d", calls, budget.remaining)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("owned original was not removed: %v", err)
+	}
+}
+
+func TestOriginalBudgetPreservesExistingCacheAndConsent(t *testing.T) {
+	oldExport, oldRender := exportEvalOriginal, renderEvalImage
+	t.Cleanup(func() { exportEvalOriginal, renderEvalImage = oldExport, oldRender })
+	exportEvalOriginal = func(context.Context, string, string, bool, int64) error {
+		t.Fatal("unexpected export")
+		return nil
+	}
+	renderEvalImage = func(context.Context, string, string, float64) error { return errors.New("render") }
+	opts, _ := evalRunOptions(t)
+	asset := photos.Asset{LocalIdentifier: "synthetic", MediaType: "image"}
+	opts.Provider = budgetProvider{[]photos.Asset{asset}}
+	opts.AllowICloudDownloads = false
+	if _, err := Run(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(opts.CacheDir, cacheName(asset))
+	if err := os.WriteFile(path, []byte("caller-owned cached original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Run(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(path); err != nil || string(got) != "caller-owned cached original" {
+		t.Fatalf("existing cached file changed: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := Run(ctx, opts); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancellation lost: %v", err)
+	}
+}

--- a/internal/photos/media_darwin.go
+++ b/internal/photos/media_darwin.go
@@ -22,6 +22,17 @@ import (
 )
 
 func ExportOriginalResource(ctx context.Context, localIdentifier, destinationPath string, allowNetwork bool) error {
+	return exportOriginalResource(ctx, localIdentifier, destinationPath, allowNetwork, 0)
+}
+
+func ExportOriginalResourceLimited(ctx context.Context, localIdentifier, destinationPath string, allowNetwork bool, maxBytes int64) error {
+	if maxBytes <= 0 {
+		return errors.New("original export byte limit must be positive")
+	}
+	return exportOriginalResource(ctx, localIdentifier, destinationPath, allowNetwork, maxBytes)
+}
+
+func exportOriginalResource(ctx context.Context, localIdentifier, destinationPath string, allowNetwork bool, maxBytes int64) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -37,6 +48,7 @@ func ExportOriginalResource(ctx context.Context, localIdentifier, destinationPat
 		return errors.New("create original export control")
 	}
 	defer C.photoscrawl_export_release(control)
+	C.photoscrawl_export_set_limit(control, C.int64_t(maxBytes))
 	canceled := make(chan struct{})
 	stop := context.AfterFunc(ctx, func() {
 		C.photoscrawl_export_cancel(control)

--- a/internal/photos/media_unsupported.go
+++ b/internal/photos/media_unsupported.go
@@ -11,6 +11,10 @@ func ExportOriginalResource(ctx context.Context, localIdentifier, destinationPat
 	return errors.New("PhotoKit original export requires macOS")
 }
 
+func ExportOriginalResourceLimited(ctx context.Context, localIdentifier, destinationPath string, allowNetwork bool, maxBytes int64) error {
+	return errors.New("PhotoKit original export requires macOS")
+}
+
 func RenderCanonicalJPEG(ctx context.Context, sourcePath, destinationPath string, quality float64) error {
 	return errors.New("canonical JPEG rendering requires macOS ImageIO/CoreImage")
 }

--- a/internal/photos/original_export_darwin.h
+++ b/internal/photos/original_export_darwin.h
@@ -1,7 +1,10 @@
 #ifndef PHOTOSCRAWL_ORIGINAL_EXPORT_H
 #define PHOTOSCRAWL_ORIGINAL_EXPORT_H
 
+#include <stdint.h>
+
 void *photoscrawl_export_create(void);
+void photoscrawl_export_set_limit(void *control, int64_t bytes);
 void photoscrawl_export_cancel(void *control);
 int photoscrawl_export_cancelled(void *control);
 void photoscrawl_export_release(void *control);

--- a/internal/photos/original_export_darwin.m
+++ b/internal/photos/original_export_darwin.m
@@ -14,6 +14,8 @@
   BOOL finished;
   BOOL cancelled;
   int descriptor;
+  uint64_t byteLimit;
+  uint64_t bytesWritten;
   PHAssetResourceDataRequestID requestID;
   NSString *stagingPath;
   NSString *destinationPath;
@@ -110,6 +112,11 @@
     if (finished) return;
     const char *bytes = data.bytes;
     NSUInteger remaining = data.length;
+    if (byteLimit > 0 && remaining > byteLimit - bytesWritten) {
+      [self failLocked:@"original resource exceeds byte limit"];
+      failed = YES;
+      remaining = 0;
+    }
     while (remaining > 0) {
       ssize_t count = write(descriptor, bytes, remaining);
       if (count < 0 && errno == EINTR) continue;
@@ -120,6 +127,7 @@
       }
       bytes += count;
       remaining -= count;
+      bytesWritten += count;
     }
   }
   if (failed) [self cancelRequest];
@@ -150,6 +158,10 @@
 
 void *photoscrawl_export_create(void) {
   return [[PCOriginalExport alloc] init];
+}
+void photoscrawl_export_set_limit(void *control, int64_t bytes) {
+  PCOriginalExport *state = (PCOriginalExport *)control;
+  @synchronized(state) { state->byteLimit = bytes > 0 ? (uint64_t)bytes : 0; }
 }
 void photoscrawl_export_cancel(void *control) {
   @autoreleasepool { [(PCOriginalExport *)control cancel]; }

--- a/internal/photos/sqlite_copy.go
+++ b/internal/photos/sqlite_copy.go
@@ -36,7 +36,7 @@ func copySQLiteWithVerifier(ctx context.Context, liveDBPath, tempPrefix string, 
 		return "", func() {}, err
 	}
 	cleanup := func() { _ = os.RemoveAll(dir) }
-	dest := filepath.Join(dir, filepath.Base(liveDBPath))
+	dest := filepath.Join(dir, "snapshot.db")
 	for attempt := 1; attempt <= 5; attempt++ {
 		if err := ctx.Err(); err != nil {
 			cleanup()

--- a/internal/photos/sqlite_copy.go
+++ b/internal/photos/sqlite_copy.go
@@ -1,0 +1,239 @@
+package photos
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/openclaw/crawlkit/store"
+)
+
+type sqliteFileState struct {
+	exists      bool
+	size        int64
+	modifiedNS  int64
+	contentHash [sha256.Size]byte
+	info        os.FileInfo
+}
+
+// CopySQLite reads source files only; SQLite opens only the private copy.
+func CopySQLite(ctx context.Context, liveDBPath string, tempPrefix string) (string, func(), error) {
+	return copySQLiteWithVerifier(ctx, liveDBPath, tempPrefix, verifySQLiteSnapshot)
+}
+
+func copySQLiteWithVerifier(ctx context.Context, liveDBPath, tempPrefix string, verify func(context.Context, string) error) (string, func(), error) {
+	resolved, err := filepath.EvalSymlinks(liveDBPath)
+	if err != nil {
+		return "", func() {}, err
+	}
+	liveDBPath = resolved
+	dir, err := os.MkdirTemp("", tempPrefix)
+	if err != nil {
+		return "", func() {}, err
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	dest := filepath.Join(dir, filepath.Base(liveDBPath))
+	for attempt := 1; attempt <= 5; attempt++ {
+		if err := ctx.Err(); err != nil {
+			cleanup()
+			return "", func() {}, fmt.Errorf("snapshot SQLite source %s: %w", liveDBPath, err)
+		}
+		_ = os.Remove(dest)
+		_ = os.Remove(dest + "-wal")
+		_ = os.Remove(dest + "-shm")
+		_ = os.Remove(dest + "-journal")
+		before, err := statSQLiteFiles(liveDBPath)
+		if err != nil {
+			cleanup()
+			return "", func() {}, err
+		}
+		copied, err := copySQLiteFiles(ctx, liveDBPath, dest, before)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			cleanup()
+			return "", func() {}, err
+		}
+		after, err := hashSQLiteFiles(ctx, liveDBPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			cleanup()
+			return "", func() {}, err
+		}
+		if sqliteFilesStable(before, copied, after) {
+			if err := verify(ctx, dest); err == nil {
+				return dest, cleanup, nil
+			}
+			if err := ctx.Err(); err != nil {
+				cleanup()
+				return "", func() {}, fmt.Errorf("snapshot SQLite source %s: %w", liveDBPath, err)
+			}
+		}
+	}
+	cleanup()
+	if err := ctx.Err(); err != nil {
+		return "", func() {}, fmt.Errorf("snapshot SQLite source %s: %w", liveDBPath, err)
+	}
+	return "", func() {}, fmt.Errorf("create consistent SQLite snapshot: source kept changing during 5 attempts")
+}
+
+func statSQLiteFiles(dbPath string) (map[string]sqliteFileState, error) {
+	out := map[string]sqliteFileState{}
+	for _, suffix := range []string{"", "-wal", "-journal"} {
+		path := dbPath + suffix
+		info, err := os.Stat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			out[suffix] = sqliteFileState{}
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("inspect SQLite source %s: %w", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("SQLite source must be a regular file")
+		}
+		out[suffix] = sqliteFileState{exists: true, size: info.Size(), modifiedNS: info.ModTime().UnixNano(), info: info}
+	}
+	if !out[""].exists {
+		return nil, fmt.Errorf("SQLite source does not exist: %s", dbPath)
+	}
+	return out, nil
+}
+
+func copySQLiteFiles(ctx context.Context, sourceDB, destDB string, before map[string]sqliteFileState) (map[string]sqliteFileState, error) {
+	out := map[string]sqliteFileState{}
+	for _, suffix := range []string{"", "-wal", "-journal"} {
+		if !before[suffix].exists {
+			out[suffix] = sqliteFileState{}
+			continue
+		}
+		digest, err := copyFileWithHash(ctx, sourceDB+suffix, destDB+suffix, before[suffix].size)
+		if err != nil {
+			return nil, err
+		}
+		state := before[suffix]
+		state.contentHash = digest
+		out[suffix] = state
+	}
+	return out, nil
+}
+
+func hashSQLiteFiles(ctx context.Context, dbPath string) (map[string]sqliteFileState, error) {
+	states, err := statSQLiteFiles(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	for _, suffix := range []string{"", "-wal", "-journal"} {
+		state := states[suffix]
+		if !state.exists {
+			continue
+		}
+		file, err := os.Open(dbPath + suffix)
+		if err != nil {
+			return nil, fmt.Errorf("open SQLite source %s: %w", dbPath+suffix, err)
+		}
+		digest := sha256.New()
+		_, copyErr := io.Copy(digest, contextReader{ctx, io.LimitReader(file, state.size)})
+		closeErr := file.Close()
+		if copyErr != nil {
+			return nil, fmt.Errorf("hash SQLite source %s: %w", dbPath+suffix, copyErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close SQLite source %s: %w", dbPath+suffix, closeErr)
+		}
+		copy(state.contentHash[:], digest.Sum(nil))
+		states[suffix] = state
+	}
+	final, err := statSQLiteFiles(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	for suffix, state := range states {
+		after := final[suffix]
+		if state.exists != after.exists || (state.exists && (!os.SameFile(state.info, after.info) ||
+			state.size != after.size || state.modifiedNS != after.modifiedNS)) {
+			return nil, os.ErrNotExist
+		}
+	}
+	return states, nil
+}
+
+func sqliteFilesStable(before, copied, after map[string]sqliteFileState) bool {
+	for _, suffix := range []string{"", "-wal", "-journal"} {
+		if before[suffix].exists != after[suffix].exists || copied[suffix].exists != after[suffix].exists {
+			return false
+		}
+		if !after[suffix].exists {
+			continue
+		}
+		if !os.SameFile(before[suffix].info, after[suffix].info) ||
+			before[suffix].size != after[suffix].size || before[suffix].modifiedNS != after[suffix].modifiedNS {
+			return false
+		}
+		if copied[suffix].contentHash != after[suffix].contentHash {
+			return false
+		}
+	}
+	return true
+}
+
+func verifySQLiteSnapshot(ctx context.Context, path string) error {
+	// Recover copied hot journals only in the private directory. The source is
+	// never opened by SQLite, so its writer locks and sidecars remain untouched.
+	db, err := store.Open(ctx, store.Options{Path: path})
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	var result string
+	if err := db.DB().QueryRowContext(ctx, `pragma quick_check`).Scan(&result); err != nil {
+		return err
+	}
+	if result != "ok" {
+		return fmt.Errorf("SQLite snapshot quick check: %s", result)
+	}
+	return nil
+}
+
+func copyFileWithHash(ctx context.Context, source, dest string, size int64) ([sha256.Size]byte, error) {
+	var outHash [sha256.Size]byte
+	in, err := os.Open(source)
+	if err != nil {
+		return outHash, fmt.Errorf("open %s: %w", source, err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return outHash, fmt.Errorf("create %s: %w", dest, err)
+	}
+	digest := sha256.New()
+	_, copyErr := io.Copy(io.MultiWriter(out, digest), contextReader{ctx, io.LimitReader(in, size)})
+	closeErr := out.Close()
+	if copyErr != nil {
+		return outHash, fmt.Errorf("copy %s: %w", source, copyErr)
+	}
+	if closeErr != nil {
+		return outHash, fmt.Errorf("close %s: %w", dest, closeErr)
+	}
+	copy(outHash[:], digest.Sum(nil))
+	return outHash, nil
+}
+
+type contextReader struct {
+	ctx context.Context
+	io.Reader
+}
+
+func (r contextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.Reader.Read(p)
+}

--- a/internal/photos/sqlite_copy_test.go
+++ b/internal/photos/sqlite_copy_test.go
@@ -18,7 +18,11 @@ func TestCopySQLiteWhitespaceSource(t *testing.T) {
 		for _, spelling := range []string{"direct", "symlink"} {
 			t.Run(journal+"/"+spelling, func(t *testing.T) {
 				ctx := context.Background()
-				source := filepath.Join(t.TempDir(), "source.db ")
+				root, err := filepath.EvalSymlinks(t.TempDir())
+				if err != nil {
+					t.Fatal(err)
+				}
+				source := filepath.Join(root, "source.db ")
 				writer, err := sql.Open("sqlite", source)
 				if err != nil {
 					t.Fatal(err)
@@ -180,7 +184,11 @@ func requireCopySidecarsAbsent(t *testing.T, path string) {
 
 func TestCopySQLitePrivateRollbackRecovery(t *testing.T) {
 	ctx := context.Background()
-	source := filepath.Join(t.TempDir(), "source.db ")
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(root, "source.db ")
 	writer, err := sql.Open("sqlite", source)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/photos/sqlite_copy_test.go
+++ b/internal/photos/sqlite_copy_test.go
@@ -1,21 +1,186 @@
 package photos
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/openclaw/crawlkit/store"
 )
 
+func TestCopySQLiteWhitespaceSource(t *testing.T) {
+	for _, journal := range []string{"DELETE", "WAL"} {
+		for _, spelling := range []string{"direct", "symlink"} {
+			t.Run(journal+"/"+spelling, func(t *testing.T) {
+				ctx := context.Background()
+				source := filepath.Join(t.TempDir(), "source.db ")
+				writer, err := sql.Open("sqlite", source)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { writer.Close() })
+				writer.SetMaxOpenConns(1)
+				if _, err := writer.Exec("pragma journal_mode=" + journal + "; pragma wal_autocheckpoint=0; create table marker(value text); insert into marker values ('committed-copy-row');"); err != nil {
+					t.Fatal(err)
+				}
+				requireLiteralCopySource(t, writer, source, journal)
+				var marker string
+				if err := writer.QueryRow("select value from marker").Scan(&marker); err != nil || marker != "committed-copy-row" {
+					t.Fatalf("fixture marker = %q: %v", marker, err)
+				}
+				selected := source
+				if spelling == "symlink" {
+					selected = filepath.Join(filepath.Dir(source), "alias.db")
+					if err := os.Symlink(source, selected); err != nil {
+						t.Fatal(err)
+					}
+					requireCopyAlias(t, selected, source)
+				}
+				before := copyFixtureFiles(t, source)
+				if journal == "WAL" && len(before["-wal"].data) == 0 {
+					t.Fatal("fixture has no committed WAL")
+				}
+				t.Cleanup(func() {
+					if !reflect.DeepEqual(before, copyFixtureFiles(t, source)) {
+						t.Error("source bytes, modes or sidecar inventory changed before connection close")
+					}
+					if spelling == "symlink" {
+						requireCopyAlias(t, selected, source)
+						requireCopySidecarsAbsent(t, selected)
+					}
+					requireCopyPathAbsent(t, strings.TrimSpace(source))
+				})
+				t.Log("literal filename, identity, journal and committed row verified before CopySQLite")
+				private, cleanup, err := CopySQLite(ctx, selected, "photoscrawl-whitespace-test-")
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer cleanup()
+				reader, err := store.OpenReadOnly(ctx, private)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer reader.Close()
+				if err := reader.DB().QueryRow("select value from marker").Scan(&marker); err != nil || marker != "committed-copy-row" {
+					t.Fatalf("copied committed row = %q: %v", marker, err)
+				}
+				if filepath.Base(private) != "snapshot.db" || filepath.Dir(private) == filepath.Dir(source) {
+					t.Fatalf("unexpected private path: %q", private)
+				}
+				for _, basename := range []string{filepath.Base(source), strings.TrimSpace(filepath.Base(source))} {
+					requireCopyPathAbsent(t, filepath.Join(filepath.Dir(private), basename))
+				}
+				info, err := os.Stat(filepath.Dir(private))
+				if err != nil || info.Mode().Perm() != 0o700 {
+					t.Fatalf("private directory permissions: %v %v", info, err)
+				}
+				for suffix, file := range copyFixtureFiles(t, private) {
+					if file.mode.Perm()&0o077 != 0 {
+						t.Errorf("private %q permissions = %v", suffix, file.mode)
+					}
+				}
+				if err := reader.Close(); err != nil {
+					t.Fatal(err)
+				}
+				cleanup()
+				cleanup()
+				requireCopyPathAbsent(t, filepath.Dir(private))
+			})
+		}
+	}
+}
+
+func requireLiteralCopySource(t *testing.T, db *sql.DB, source, journal string) {
+	t.Helper()
+	var seq int
+	var name, filename, mode string
+	if err := db.QueryRow("pragma database_list").Scan(&seq, &name, &filename); err != nil {
+		t.Fatal(err)
+	}
+	if name != "main" || filename != source {
+		t.Fatalf("fixture SQLite filename = %q (%q), want literal %q", filename, name, source)
+	}
+	selected, err := os.Stat(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	literal, err := os.Stat(source)
+	if err != nil || !os.SameFile(selected, literal) {
+		t.Fatalf("fixture literal identity mismatch: %v", err)
+	}
+	if err := db.QueryRow("pragma journal_mode").Scan(&mode); err != nil || !strings.EqualFold(mode, journal) {
+		t.Fatalf("fixture journal mode = %q, want %q: %v", mode, journal, err)
+	}
+	requireCopyPathAbsent(t, strings.TrimSpace(source))
+}
+
+func requireCopyAlias(t *testing.T, alias, source string) {
+	t.Helper()
+	link, err := os.Lstat(alias)
+	if err != nil || link.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("fixture alias is not a symlink: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(alias)
+	if err != nil || resolved != source {
+		t.Fatalf("fixture alias resolves to %q, want %q: %v", resolved, source, err)
+	}
+	selected, err := os.Stat(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	literal, err := os.Stat(source)
+	if err != nil || !os.SameFile(selected, literal) {
+		t.Fatalf("fixture alias identity mismatch: %v", err)
+	}
+}
+
+type copyFixtureFile struct {
+	mode os.FileMode
+	data []byte
+}
+
+func copyFixtureFiles(t *testing.T, path string) map[string]copyFixtureFile {
+	t.Helper()
+	files := map[string]copyFixtureFile{}
+	for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
+		info, err := os.Stat(path + suffix)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(path + suffix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[suffix] = copyFixtureFile{info.Mode(), data}
+	}
+	return files
+}
+
+func requireCopyPathAbsent(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Fatalf("unexpected path %q: %v", path, err)
+	}
+}
+
+func requireCopySidecarsAbsent(t *testing.T, path string) {
+	t.Helper()
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		requireCopyPathAbsent(t, path+suffix)
+	}
+}
+
 func TestCopySQLitePrivateRollbackRecovery(t *testing.T) {
 	ctx := context.Background()
-	source := filepath.Join(t.TempDir(), "source.db")
+	source := filepath.Join(t.TempDir(), "source.db ")
 	writer, err := sql.Open("sqlite", source)
 	if err != nil {
 		t.Fatal(err)
@@ -28,6 +193,16 @@ with recursive n(i) as (select 1 union all select i+1 from n where i<32)
 insert into item select i, 1, zeroblob(4096) from n;`); err != nil {
 		t.Fatal(err)
 	}
+	requireLiteralCopySource(t, writer, source, "DELETE")
+	var originalCount, originalMinimum, originalMaximum int
+	if err := writer.QueryRow("select count(*), min(value), max(value) from item").Scan(&originalCount, &originalMinimum, &originalMaximum); err != nil || originalCount != 32 || originalMinimum != 1 || originalMaximum != 1 {
+		t.Fatalf("fixture original rows = %d/%d/%d: %v", originalCount, originalMinimum, originalMaximum, err)
+	}
+	alias := filepath.Join(filepath.Dir(source), "alias.db")
+	if err := os.Symlink(source, alias); err != nil {
+		t.Fatal(err)
+	}
+	requireCopyAlias(t, alias, source)
 	tx, err := writer.BeginTx(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -36,14 +211,20 @@ insert into item select i, 1, zeroblob(4096) from n;`); err != nil {
 	if _, err := tx.Exec(`update item set value=2, payload=zeroblob(8192)`); err != nil {
 		t.Fatal(err)
 	}
-	before := map[string][]byte{}
-	for _, suffix := range []string{"", "-journal"} {
-		before[suffix], err = os.ReadFile(source + suffix)
-		if err != nil {
-			t.Fatal(err)
-		}
+	before := copyFixtureFiles(t, source)
+	if len(before["-journal"].data) == 0 {
+		t.Fatal("fixture has no active rollback journal")
 	}
-	private, cleanup, err := CopySQLite(ctx, source, "photoscrawl-journal-test-")
+	defer func() {
+		if !reflect.DeepEqual(before, copyFixtureFiles(t, source)) {
+			t.Error("source rollback recovery changed bytes, modes or sidecar inventory")
+		}
+		requireCopyAlias(t, alias, source)
+		requireCopySidecarsAbsent(t, alias)
+		requireCopyPathAbsent(t, strings.TrimSpace(source))
+	}()
+	t.Log("literal filename, original rows and active rollback journal verified before CopySQLite")
+	private, cleanup, err := CopySQLite(ctx, alias, "photoscrawl-journal-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,17 +241,6 @@ insert into item select i, 1, zeroblob(4096) from n;`); err != nil {
 	if count != 32 || minimum != 1 || maximum != 1 {
 		t.Fatalf("uncommitted state leaked: count=%d min=%d max=%d", count, minimum, maximum)
 	}
-	for suffix, want := range before {
-		got, err := os.ReadFile(source + suffix)
-		if err != nil || !bytes.Equal(got, want) {
-			t.Fatalf("source rollback recovery mutated %q: %v", suffix, err)
-		}
-	}
-	for _, suffix := range []string{"-wal", "-shm"} {
-		if _, err := os.Stat(source + suffix); !os.IsNotExist(err) {
-			t.Fatalf("source sidecar %s created: %v", suffix, err)
-		}
-	}
 }
 
 func TestCopySQLiteFinalVerificationCancellation(t *testing.T) {
@@ -81,7 +251,9 @@ func TestCopySQLiteFinalVerificationCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	attempts := 0
-	_, cleanup, err := copySQLiteWithVerifier(ctx, source, "photoscrawl-cancel-test-", func(context.Context, string) error {
+	var private string
+	_, cleanup, err := copySQLiteWithVerifier(ctx, source, "photoscrawl-cancel-test-", func(_ context.Context, path string) error {
+		private = path
 		attempts++
 		if attempts == 5 {
 			cancel()
@@ -95,5 +267,23 @@ func TestCopySQLiteFinalVerificationCancellation(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), source) {
 		t.Fatalf("cancellation lacks source path: %v", err)
+	}
+	if private == "" {
+		t.Fatal("verifier was not called")
+	}
+	requireCopyPathAbsent(t, filepath.Dir(private))
+}
+
+func TestCopySQLiteCanceledBeforeCopy(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "source.db ")
+	if err := os.WriteFile(source, []byte("synthetic cancellation input"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	private, cleanup, err := CopySQLite(ctx, source, "photoscrawl-early-cancel-test-")
+	cleanup()
+	if private != "" || !errors.Is(err, context.Canceled) {
+		t.Fatalf("private = %q, error = %v", private, err)
 	}
 }

--- a/internal/photos/sqlite_copy_test.go
+++ b/internal/photos/sqlite_copy_test.go
@@ -1,0 +1,99 @@
+package photos
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/crawlkit/store"
+)
+
+func TestCopySQLitePrivateRollbackRecovery(t *testing.T) {
+	ctx := context.Background()
+	source := filepath.Join(t.TempDir(), "source.db")
+	writer, err := sql.Open("sqlite", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	writer.SetMaxOpenConns(1)
+	if _, err := writer.Exec(`pragma journal_mode=DELETE; pragma cache_size=1;
+create table item(id integer primary key, value integer, payload blob);
+with recursive n(i) as (select 1 union all select i+1 from n where i<32)
+insert into item select i, 1, zeroblob(4096) from n;`); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := writer.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`update item set value=2, payload=zeroblob(8192)`); err != nil {
+		t.Fatal(err)
+	}
+	before := map[string][]byte{}
+	for _, suffix := range []string{"", "-journal"} {
+		before[suffix], err = os.ReadFile(source + suffix)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	private, cleanup, err := CopySQLite(ctx, source, "photoscrawl-journal-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	reader, err := store.OpenReadOnly(ctx, private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	var count, minimum, maximum int
+	if err := reader.DB().QueryRow("select count(*), min(value), max(value) from item").Scan(&count, &minimum, &maximum); err != nil {
+		t.Fatal(err)
+	}
+	if count != 32 || minimum != 1 || maximum != 1 {
+		t.Fatalf("uncommitted state leaked: count=%d min=%d max=%d", count, minimum, maximum)
+	}
+	for suffix, want := range before {
+		got, err := os.ReadFile(source + suffix)
+		if err != nil || !bytes.Equal(got, want) {
+			t.Fatalf("source rollback recovery mutated %q: %v", suffix, err)
+		}
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if _, err := os.Stat(source + suffix); !os.IsNotExist(err) {
+			t.Fatalf("source sidecar %s created: %v", suffix, err)
+		}
+	}
+}
+
+func TestCopySQLiteFinalVerificationCancellation(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "source.db")
+	if err := os.WriteFile(source, []byte("synthetic verification input"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	attempts := 0
+	_, cleanup, err := copySQLiteWithVerifier(ctx, source, "photoscrawl-cancel-test-", func(context.Context, string) error {
+		attempts++
+		if attempts == 5 {
+			cancel()
+			return ctx.Err()
+		}
+		return errors.New("synthetic retry")
+	})
+	cleanup()
+	if attempts != 5 || !errors.Is(err, context.Canceled) {
+		t.Fatalf("attempts=%d cancellation=%v", attempts, err)
+	}
+	if !strings.Contains(err.Error(), source) {
+		t.Fatalf("cancellation lacks source path: %v", err)
+	}
+}

--- a/internal/photos/sqlite_snapshot.go
+++ b/internal/photos/sqlite_snapshot.go
@@ -19,7 +19,12 @@ func (SQLiteSnapshotProvider) Snapshot(ctx context.Context, libraryPath string) 
 	if _, err := os.Stat(dbPath); err != nil {
 		return LibrarySnapshot{}, fmt.Errorf("open Photos sqlite snapshot: %w", err)
 	}
-	db, err := store.OpenReadOnly(ctx, dbPath)
+	privatePath, cleanup, err := CopySQLite(ctx, dbPath, "photoscrawl-provider-")
+	if err != nil {
+		return LibrarySnapshot{}, err
+	}
+	defer cleanup()
+	db, err := store.OpenReadOnly(ctx, privatePath)
 	if err != nil {
 		return LibrarySnapshot{}, fmt.Errorf("open Photos sqlite snapshot: %w", err)
 	}
@@ -44,7 +49,7 @@ func (SQLiteSnapshotProvider) Snapshot(ctx context.Context, libraryPath string) 
 		PhotosVersion: "unknown",
 		Metadata: map[string]any{
 			"source":        "Photos.sqlite",
-			"snapshot":      "read_only_sqlite_transaction",
+			"snapshot":      "verified_private_sqlite_copy",
 			"database_path": "database/Photos.sqlite",
 			"warning":       "Private Photos Core Data schema; use as fallback evidence, not as the only source strategy.",
 		},

--- a/internal/photos/sqlite_snapshot_test.go
+++ b/internal/photos/sqlite_snapshot_test.go
@@ -1,6 +1,7 @@
 package photos
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
@@ -27,6 +28,13 @@ func TestSQLiteSnapshotProviderReadsSyntheticLibrary(t *testing.T) {
 	if err := createSyntheticPhotosDB(db.DB()); err != nil {
 		t.Fatal(err)
 	}
+	before := map[string][]byte{}
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		before[suffix], err = os.ReadFile(dbPath + suffix)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	snapshot, err := SQLiteSnapshotProvider{}.Snapshot(context.Background(), libraryPath)
 	if err != nil {
@@ -34,6 +42,15 @@ func TestSQLiteSnapshotProviderReadsSyntheticLibrary(t *testing.T) {
 	}
 	if snapshot.Provider != "photos_sqlite_snapshot" {
 		t.Fatalf("provider = %q", snapshot.Provider)
+	}
+	if snapshot.Metadata["snapshot"] != "verified_private_sqlite_copy" {
+		t.Fatalf("snapshot evidence = %#v", snapshot.Metadata)
+	}
+	for suffix, want := range before {
+		got, err := os.ReadFile(dbPath + suffix)
+		if err != nil || !bytes.Equal(got, want) {
+			t.Fatalf("source sidecar %q changed: %v", suffix, err)
+		}
 	}
 	if len(snapshot.Assets) != 2 {
 		t.Fatalf("assets = %d, want 2", len(snapshot.Assets))


### PR DESCRIPTION
## What Problem This Solves

Refreshing one Photos library could replace observations belonging to another library, switching between PhotoKit and SQLite fallback could lose continuity for an asset, and an unsuitable archive path could change unrelated database files before rejection. Photo-card preparation could also make excessive attempts or retain downloaded originals longer than needed.

A trailing-whitespace archive name could validate a different file from the one SQLite opened, including the separate library-binding check. A normal symlink to a whitespace-ending filename could also make private-copy verification read an empty sibling instead of the copied database.

## Why This Change Was Made

Scope observation replacement to the selected library and resolve recognized provider identifiers using durable same-library evidence while retaining existing asset IDs and full native identifiers. Reject ambiguous historical matches without merging or rekeying them. Validate archive destinations before writable access, read fallback databases through private snapshots, and bound original-download attempts and streamed bytes.

Archive checks apply the SQLite opener's filename normalization first. Initialization rejects unstable trimmed names before creating their parent directory, while preserving the displayed database spelling. Private copies use a stable filename without changing literal source paths or their WAL/journal mapping.

Consume released CrawlKit v0.15.0 without changing the Go 1.27.0 minimum or preferred Go 1.27.1 toolchain. Add a native pinned vulnerability scan with a frozen public database and complete configuration/output/finding evaluation; JSON exit zero alone is not a passing result.

## User Impact

- Refreshing a valid empty library clears only that library's observations.
- Supported provider changes preserve existing asset, resource, evidence and queue references.
- Pre-write archive checks reject foreign and unsafe destinations before modifying them.
- Private SQLite copies retain committed rows and library bindings when a source filename ends in whitespace, including ordinary symlink access.
- Photo-card preparation limits originals to 256 MiB each and 512 MiB per run, and removes only its own temporary original files.
- No asset-ID migration or historical duplicate merge is included.

## Evidence

- With the actual published v0.15.0 graph and no replacements, Linux Go 1.27.1 passed 108 top-level tests, full build/vet, tidy-diff, module verification and five temporary-home CLI smokes before the final private-filename correction.
- The private-filename regression first reproduced missing copied tables, failed library-binding lookup, and foreign-file permission changes against the old source. With the one-line correction, both affected packages passed 80 top-level tests, plus scoped build/vet, under an isolated network-denied temporary home on Go 1.27.1.
- Those fixtures verify the literal SQLite filename and identity, sentinel rows, active committed WAL and genuine rollback-journal recovery. Foreign refusals preserve main/WAL/SHM/journal bytes, modes and presence before closing the source connection. No read-only SHM allowance is used for private-copy refusal.
- A macOS fixture setup failure exposed the temporary directory's `/var` alias to `/private/var`. The tests now resolve only the newly created parent directory before appending the unchanged whitespace filename. All assertions remain strict; the four affected families passed locally with both test binaries explicitly verifying a symlinked temporary directory. The corrected head also passed native CI; the earlier failed test and skipped Build remain historical failures, not passes.
- Synthetic fixtures also cover library-scoped replacement, alternating provider identifiers, ambiguity rollback, source-preserving snapshots, archive rejection and original-download budgets.
- Direct read-only WAL tests separately account only for SQLite's shared reader marks while checking all other bytes and file modes, sizes and inventory.
- The existing fake PhotoKit fixture directly exercises the limited-export API: exact 18-byte success in 7+11-byte chunks, single-chunk and cumulative overflow at a 17-byte limit, and cancellation after a confirmed partial write with late callbacks gated until API return. Assertions cover exact results, destination preservation, cancellation acknowledgment where applicable and staging cleanup.
- [Earlier source macOS CI](https://github.com/openclaw/photoscrawl/actions/runs/34291919957) passed full tests, build, vet, deadcode, tidy and module verification on Go 1.27.1, macOS 26.6.2 arm64, including all 18 synthetic native export cases. The required fake PhotoKit library does not access a real Photos library.
- [Final corrected-head macOS CI](https://github.com/openclaw/photoscrawl/actions/runs/34298211177) passed full tests, native build and version assertion, vet, deadcode, tidy and module verification on Go 1.27.1, macOS 26.6.2 arm64. Exact checkout/tree attribution includes the final private-filename correction and all 18 unconditional synthetic export cases.
- The same run's downloaded vulnerability artifact was checked against its digest, exact native configuration, frozen public database, complete raw stream, completion record and independently reconstructed SBOM. It contains 170 raw OSV messages covering 168 distinct advisory IDs and zero called, imported-only or module-only findings. An optional skipped check is not counted as a pass.
- Real PhotoKit identifier lookup across provider changes remains unverified. Synthetic callbacks do not establish real PhotoKit/iCloud scheduling, TCC behavior or large-file stress. Photos' native compiler proof is Go 1.27.1, not literal Go 1.27.0. No signed release artifact or notarization proof is claimed.

This is source-change and synthetic runtime evidence, not an application release.
